### PR TITLE
Allows triggers to subscribe even if disabled()

### DIFF
--- a/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
@@ -167,13 +167,6 @@ public class CIBuildTrigger extends Trigger<BuildableItem> {
 				log.warning("Exception while trying to save job: " + e.getMessage());
 			}
 		}
-		if (job instanceof AbstractProject) {
-			AbstractProject aJob = (AbstractProject) job;
-			if (aJob.isDisabled()) {
-				log.info("Job '" + job.getFullName() + "' is disabled, not subscribing.");
-				return;
-			}
-		}
 		try {
 			stopTriggerThread();
 			JMSMessagingProvider provider = GlobalCIConfiguration.get()


### PR DESCRIPTION
- This will allow jobs' triggers to function once a job
  is re-enabled.
- Currently, if a job is disabled, the trigger will never start unless the job
  is re-saved().