### PR TITLE
[CID-3194] CI plugin overwriting CI_MESSAGE while jobs are queued.

### DIFF
--- a/src/main/java/com/redhat/jenkins/plugins/ci/CIShouldScheduleQueueAction.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/CIShouldScheduleQueueAction.java
@@ -1,0 +1,36 @@
+package com.redhat.jenkins.plugins.ci;
+
+import hudson.model.Action;
+import hudson.model.Queue.QueueAction;
+
+import java.util.List;
+
+public class CIShouldScheduleQueueAction implements QueueAction {
+
+    public Boolean schedule = false;
+
+    public CIShouldScheduleQueueAction(Boolean schedule) {
+        this.schedule = schedule;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldSchedule(List<Action> actions) {
+         return schedule;
+    }
+
+}

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/CIBuildTrigger/config.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/CIBuildTrigger/config.jelly
@@ -26,6 +26,19 @@
   -->
   <j:set var="gdescriptor" value="${app.getDescriptorByName('com.redhat.jenkins.plugins.ci.GlobalCIConfiguration');}"/>
 
+  <!--
+    I haven't been able to find a way to get the checkbox lined up correctly so things look good.  Work
+    around that by stealing HTML from <f:entry> and embedding it directly here.
+  -->
+  <j:set target="${attrs}" property="chkhelp" value="${descriptor.getHelpFile('noSquash')}" />
+  <tr>
+    <td class="setting-leftspace"><st:nbsp/></td>
+    <td colspan="2">
+      <f:checkbox field="noSquash" title="${%Schedule a new job for every triggering message.}" default="false"/>
+    </td>
+    <f:helpLink url="${attrs.chkhelp}" featureName="${%Schedule a new job for every triggering message.}"/>
+  </tr>
+  
   <f:entry title="${%Messaging Provider}" field="providerName">
       <f:select onchange="javascript: onProviderChange(this, 'subscriber');"/>
   </f:entry>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/CIBuildTrigger/help-noSquash.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/CIBuildTrigger/help-noSquash.html
@@ -1,0 +1,8 @@
+<div>
+  <p>Schedule a new job for every triggering message.</p>
+  <p>Normally if a job is queued and another triggering message is received, a new
+     job is not submitted and the job is "squashed" into the job already queued. Checking 
+     this option forces a new job to be submitted for every triggering message that is
+     received.
+  </p>
+</div>

--- a/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
+++ b/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
@@ -134,6 +134,11 @@ public class AmqMessagingPluginIntegrationTest extends SharedMessagingPluginInte
     }
 
     @Test
+    public void testSimpleCIEventTriggerWithCheckNoSquash() throws Exception {
+        _testSimpleCIEventTriggerWithCheckNoSquash();
+    }
+
+    @Test
     public void testSimpleCIEventTriggerWithWildcardInSelector() throws Exception {
         _testSimpleCIEventTriggerWithWildcardInSelector();
     }

--- a/src/test/java/com/redhat/jenkins/plugins/ci/integration/FedMsgMessagingPluginIntegrationTest.java
+++ b/src/test/java/com/redhat/jenkins/plugins/ci/integration/FedMsgMessagingPluginIntegrationTest.java
@@ -100,6 +100,11 @@ public class FedMsgMessagingPluginIntegrationTest extends SharedMessagingPluginI
     }
 
     @Test
+    public void testSimpleCIEventTriggerWithCheckNoSquash() throws Exception {
+        _testSimpleCIEventTriggerWithCheckNoSquash();
+    }
+
+    @Test
     public void testSimpleCIEventTriggerWithRegExpCheck() throws Exception {
         _testSimpleCIEventTriggerWithRegExpCheck();
     }

--- a/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/CIEventTrigger.java
+++ b/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/CIEventTrigger.java
@@ -31,6 +31,7 @@ import org.jenkinsci.test.acceptance.po.WorkflowJob;
  */
 @Describable("CI event")
 public class CIEventTrigger extends PageAreaImpl {
+    public final Control noSquash = control("noSquash");
     public final Control providerName = control("providerName");
     public final Control overrides = control("overrides");
     public final Control topic = control("overrides/topic");


### PR DESCRIPTION
Add option to CIBuildTrigger to *not* squash jobs, thereby insuring that each triggering message results in a separate job.