### PR TITLE
Mark previous versions as not compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <version>1.120</version>
                 <configuration>
+                    <compatibleSinceVersion>1.0.38</compatibleSinceVersion>
                     <systemProperties>
                     <systemProperty>
                         <name>hudson.model.ParametersAction.keepUndefinedParameters</name>


### PR DESCRIPTION
Mark previous versions as not compatible due to selector being removed in FedMsg provider