### PR TITLE
Use durable queue consumers when subscribing jobs in ActiveMq

### DIFF
--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -104,7 +104,7 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
                         if (provider.getUseQueues()) {
                             Queue destination = session.createQueue(this.topic);
-                            subscriber = session.createConsumer(destination, selector, false);
+                            subscriber = session.createDurableConsumer(destination, jobname, selector, false);
                         } else {
                             Topic destination = session.createTopic(this.topic);
                             subscriber = session.createDurableSubscriber(destination, jobname, selector, false);
@@ -508,7 +508,7 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                     Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
                     if (provider.getUseQueues()) {
                         Queue destination = session.createQueue(ltopic);
-                        consumer = session.createConsumer(destination, pd.getSelector(), false);
+                        consumer = session.createDurableConsumer(destination, jobname, pd.getSelector(), false);
                     } else {
                         Topic destination = session.createTopic(ltopic);
                         consumer = session.createDurableSubscriber(destination, jobname, pd.getSelector(), false);


### PR DESCRIPTION
For some reason bee4845, the commit that added queue support, didn't mirror the
durability of topic subscriptions to queue consumers. I suspect this is the
cause of sporadic dropped messages I've seen when the provider is configured to
use queues.

`ActiveMqMessagingWorker#subscribe` is the smallest and most important change.

I applied a similar fix to `ActiveMqMessagingWorker#waitForMessage` and
`ActiveMqMessageWatcher#watch`, but actual durability in those cases isn't
possible without making them to retry on a timeout/error. I suspect that
sporadic dropped messages will still be a problem when a job waits for a
message while executing.