### PR TITLE
add pipeline syntax support for CIBuildTrigger

### DIFF
--- a/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.model.Jenkins;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -575,7 +576,7 @@ public class CIBuildTrigger extends Trigger<BuildableItem> {
 	    return (CIBuildTriggerDescriptor) Jenkins.getInstance().getDescriptor(getClass());
 	}
 
-    @Extension
+    @Extension @Symbol("ciBuildTrigger")
 	public static class CIBuildTriggerDescriptor extends TriggerDescriptor {
 
 		public FormValidation doCheckField(@QueryParameter String value) {

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQPublisherProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQPublisherProviderData.java
@@ -7,6 +7,7 @@ import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -122,6 +123,7 @@ public class ActiveMQPublisherProviderData extends ActiveMQProviderData {
     }
 
     @Extension
+    @Symbol("activeMQPublisher")
     public static class ActiveMQPublisherProviderDataDescriptor extends ActiveMQProviderDataDescriptor {
 
         @Override

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQSubscriberProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQSubscriberProviderData.java
@@ -11,6 +11,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -129,6 +130,7 @@ public class ActiveMQSubscriberProviderData extends ActiveMQProviderData {
     }
 
     @Extension
+    @Symbol("activeMQSubscriber")
     public static class ActiveMQSubscriberProviderDataDescriptor extends ActiveMQProviderDataDescriptor {
 
         @Override

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/FedMsgPublisherProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/FedMsgPublisherProviderData.java
@@ -7,6 +7,7 @@ import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -98,6 +99,7 @@ public class FedMsgPublisherProviderData extends FedMsgProviderData {
     }
 
     @Extension
+    @Symbol("fedmsgPublisher")
     public static class FedMsgPublisherProviderDataDescriptor extends FedMsgProviderDataDescriptor {
 
         @Override

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/FedMsgSubscriberProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/FedMsgSubscriberProviderData.java
@@ -11,6 +11,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -117,6 +118,7 @@ public class FedMsgSubscriberProviderData extends FedMsgProviderData {
     }
 
     @Extension
+    @Symbol("fedmsgSubscriber")
     public static class FedMsgSubscriberProviderDataDescriptor extends FedMsgProviderDataDescriptor {
 
         @Override


### PR DESCRIPTION
This PR adds Jenkins pipeline syntax support for CIBuildTrigger by applying the `@Symbol` annotation to descriptors of CIBuildTrigger and provider data descendants.

For example, to trigger a Jenkins pipeline build on CI messages with `Consumer.rh-jenkins-ci-plugin.${env.JOB_BASE_NAME}.VirtualTopic.eng.repotracker.container.tag.>` topics, a user can write a Jenkinsfile like this:

``` Jenkinsfile

pipeline {
    agent { label 'master' }
    triggers {
        ciBuildTrigger(noSquash: true,
          providerData: activeMQSubscriber(
            name: 'Red Hat UMB',
            overrides: [topic: "Consumer.rh-jenkins-ci-plugin.${env.JOB_BASE_NAME}.VirtualTopic.eng.repotracker.container.tag.>"],
            selector: "repo='factory2/waiverdb'",
            checks: [
              [field: '$.action', expectedValue: 'added|updated'],
            ],
          )
        )
    }
    stages {
        stage('foo') {
            steps {
                echo 'Hello world!'
            }
        }
    }

}

```