### PR TITLE
update activemq-amqp from 5.14.5 to 5.15.9 - CVE-2019-0222 CVE-2018-8006

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-amqp</artifactId>
-            <version>5.14.5</version>
+            <version>5.15.9</version>
         </dependency>
         <dependency>
             <groupId>org.zeromq</groupId>


### PR DESCRIPTION
https://www.cvedetails.com/cve/CVE-2019-0222/

https://www.cvedetails.com/product/19047/Apache-Activemq.html?vendor_id=45

http://activemq.apache.org/download-archives