### PR TITLE
Add simple client for RabbitMQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
              than the parent version above
         -->
         <java.level>8</java.level>
-        <jenkins.version>2.107.3</jenkins.version>
+        <jenkins.version>2.176.2</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
@@ -141,6 +141,16 @@
                     <artifactId>tools</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <version>5.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
@@ -1,5 +1,7 @@
 package com.redhat.jenkins.plugins.ci;
 
+import com.redhat.jenkins.plugins.ci.messaging.FedMsgMessagingProvider;
+import com.redhat.jenkins.plugins.ci.provider.data.*;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.PluginManager;
@@ -30,11 +32,6 @@ import com.redhat.jenkins.plugins.ci.messaging.ActiveMqMessagingProvider;
 import com.redhat.jenkins.plugins.ci.messaging.JMSMessagingProvider;
 import com.redhat.jenkins.plugins.ci.messaging.topics.DefaultTopicProvider;
 import com.redhat.jenkins.plugins.ci.messaging.topics.TopicProvider.TopicProviderDescriptor;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQSubscriberProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
 
 /*
  * The MIT License
@@ -248,8 +245,10 @@ public final class GlobalCIConfiguration extends GlobalConfiguration {
             for (JMSMessagingProvider p : getConfigs()) {
                 if (p instanceof ActiveMqMessagingProvider) {
                     pds.add(new ActiveMQSubscriberProviderData(p.getName()));
-                } else {
+                } else if (p instanceof FedMsgMessagingProvider) {
                     pds.add(new FedMsgSubscriberProviderData(p.getName()));
+                } else {
+                    pds.add(new RabbitMQSubscriberProviderData(p.getName()));
                 }
             }
         }
@@ -262,8 +261,10 @@ public final class GlobalCIConfiguration extends GlobalConfiguration {
             for (JMSMessagingProvider p : getConfigs()) {
                 if (p instanceof ActiveMqMessagingProvider) {
                     pds.add(new ActiveMQPublisherProviderData(p.getName()));
-                } else {
+                } else if (p instanceof FedMsgMessagingProvider) {
                     pds.add(new FedMsgPublisherProviderData(p.getName()));
+                } else {
+                    pds.add(new RabbitMQPublisherProviderData(p.getName()));
                 }
             }
         }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/authentication/AuthenticationMethod.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/authentication/AuthenticationMethod.java
@@ -1,14 +1,6 @@
 package com.redhat.jenkins.plugins.ci.authentication;
 
-import hudson.ExtensionList;
-import hudson.model.Describable;
-import hudson.model.Descriptor;
-
 import java.io.Serializable;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 
@@ -35,26 +27,9 @@ import jenkins.model.Jenkins;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-public abstract class AuthenticationMethod implements Describable<AuthenticationMethod>, Serializable  {
+public abstract class AuthenticationMethod implements Serializable  {
 
     private static final long serialVersionUID = -6077120270692721571L;
-    private transient static final Logger log = Logger.getLogger(AuthenticationMethod.class.getName());
-
-    public abstract static class AuthenticationMethodDescriptor extends Descriptor<AuthenticationMethod> {
-        public static ExtensionList<AuthenticationMethodDescriptor> all() {
-            return Jenkins.getInstance().getExtensionList(AuthenticationMethodDescriptor.class);
-        }
-
-        public static boolean isValidURL(String url) {
-            try {
-                new URI(url);
-            } catch (URISyntaxException e) {
-                log.log(Level.SEVERE, "URISyntaxException, returning false.");
-                return false;
-            }
-            return true;
-        }
-    }
 
     /**
      * Taken from gerrit-trigger-plugin

--- a/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/RabbitMQAuthenticationMethod.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/RabbitMQAuthenticationMethod.java
@@ -1,15 +1,10 @@
-package com.redhat.jenkins.plugins.ci.authentication.activemq;
+package com.redhat.jenkins.plugins.ci.authentication.rabbitmq;
 
-import hudson.ExtensionList;
+import com.rabbitmq.client.ConnectionFactory;
+
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-
-import org.apache.activemq.ActiveMQConnectionFactory;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import hudson.ExtensionList;
 
 import jenkins.model.Jenkins;
 
@@ -38,27 +33,16 @@ import com.redhat.jenkins.plugins.ci.authentication.AuthenticationMethod;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-public abstract class ActiveMQAuthenticationMethod extends AuthenticationMethod implements Describable<ActiveMQAuthenticationMethod> {
+public abstract class RabbitMQAuthenticationMethod extends AuthenticationMethod implements Describable<RabbitMQAuthenticationMethod> {
 
     private static final long serialVersionUID = -6077120270692721571L;
-    private transient static final Logger log = Logger.getLogger(AuthenticationMethod.class.getName());
 
-    public abstract static class AuthenticationMethodDescriptor extends Descriptor<ActiveMQAuthenticationMethod> {
+    public abstract static class AuthenticationMethodDescriptor extends Descriptor<RabbitMQAuthenticationMethod> {
         public static ExtensionList<AuthenticationMethodDescriptor> all() {
             return Jenkins.getInstance().getExtensionList(AuthenticationMethodDescriptor.class);
         }
-
-        public static boolean isValidURL(String url) {
-            try {
-                new URI(url);
-            } catch (URISyntaxException e) {
-                log.log(Level.SEVERE, "URISyntaxException, returning false.");
-                return false;
-            }
-            return true;
-        }
     }
 
-
-    public abstract ActiveMQConnectionFactory getConnectionFactory(String broker);
+    public abstract ConnectionFactory getConnectionFactory(String hostName, Integer portNumber,
+                                                           String VirtualHost);
 }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod.java
@@ -1,28 +1,29 @@
-package com.redhat.jenkins.plugins.ci.authentication.activemq;
+package com.redhat.jenkins.plugins.ci.authentication.rabbitmq;
 
-import com.redhat.jenkins.plugins.ci.Messages;
-import com.redhat.utils.PluginUtils;
-import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.activemq.ActiveMQSslConnectionFactory;
-import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Session;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DefaultSaslConfig;
+
+import javax.net.ssl.*;
 import javax.servlet.ServletException;
+import java.io.FileInputStream;
+import java.security.KeyStore;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.redhat.jenkins.plugins.ci.Messages;
 /*
  * The MIT License
  *
@@ -46,22 +47,28 @@ import java.util.logging.Logger;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-public class SSLCertificateAuthenticationMethod extends ActiveMQAuthenticationMethod {
+public class SSLCertificateAuthenticationMethod extends RabbitMQAuthenticationMethod {
     private static final long serialVersionUID = -5934219869726669459L;
     private transient static final Logger log = Logger.getLogger(SSLCertificateAuthenticationMethod.class.getName());
 
+    private String username;
     private String keystore;
     private Secret keypwd = Secret.fromString("");
     private String truststore;
     private Secret trustpwd = Secret.fromString("");
 
     @DataBoundConstructor
-    public SSLCertificateAuthenticationMethod(String keystore, Secret keypwd, String truststore, Secret trustpwd) {
+    public SSLCertificateAuthenticationMethod(String username, String keystore, Secret keypwd, String truststore, Secret trustpwd) {
+        this.setUsername(username);
         this.setKeystore(keystore);
         this.setKeypwd(keypwd);
         this.setTruststore(truststore);
         this.setTrustpwd(trustpwd);
     }
+
+    public String getUsername() { return username; }
+
+    public void setUsername(String username) { this.username = username; }
 
     public String getKeystore() {
         return keystore;
@@ -77,12 +84,6 @@ public class SSLCertificateAuthenticationMethod extends ActiveMQAuthenticationMe
 
     public void setKeypwd(Secret password) {
         this.keypwd = password;
-    }
-
-    private String getSubstitutedValue(String value) {
-        EnvVars vars = new EnvVars();
-        vars.put("JENKINS_HOME", Jenkins.getInstance().getRootDir().toString());
-        return PluginUtils.getSubstitutedValue(value, vars);
     }
 
     public String getTruststore() {
@@ -102,13 +103,32 @@ public class SSLCertificateAuthenticationMethod extends ActiveMQAuthenticationMe
     }
 
     @Override
-    public ActiveMQSslConnectionFactory getConnectionFactory(String broker) {
+    public ConnectionFactory getConnectionFactory(String hostName, Integer portNumber, String virtualHost) {
         try {
-            ActiveMQSslConnectionFactory connectionFactory = new ActiveMQSslConnectionFactory(broker);
-            connectionFactory.setKeyStore(getSubstitutedValue(getKeystore()));
-            connectionFactory.setKeyStorePassword(Secret.toString(getKeypwd()));
-            connectionFactory.setTrustStore(getSubstitutedValue(getTruststore()));
-            connectionFactory.setTrustStorePassword(Secret.toString(getTrustpwd()));
+            // Prepare SSL context
+            KeyStore ks = KeyStore.getInstance("PKCS12");
+            ks.load(new FileInputStream(getKeystore()), getKeypwd().getPlainText().toCharArray());
+
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
+            keyManagerFactory.init(ks, getKeypwd().getPlainText().toCharArray());
+
+            KeyStore tks = KeyStore.getInstance("JKS");
+            tks.load(new FileInputStream(getTruststore()), getTrustpwd().getPlainText().toCharArray());
+
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("SunX509");
+            trustManagerFactory.init(tks);
+
+            SSLContext c = SSLContext.getInstance("TLSv1.2");
+            c.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
+
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.setUsername(getUsername());
+            connectionFactory.setHost(hostName);
+            connectionFactory.setPort(portNumber);
+            connectionFactory.setVirtualHost(virtualHost);
+            connectionFactory.useSslProtocol(c);
+            connectionFactory.setSaslConfig(DefaultSaslConfig.EXTERNAL);
+            connectionFactory.enableHostnameVerification();
             return connectionFactory;
         } catch (Exception e) {
             log.log(Level.SEVERE, "Unhandled exception creating connection factory.", e);;
@@ -117,7 +137,7 @@ public class SSLCertificateAuthenticationMethod extends ActiveMQAuthenticationMe
     }
 
     @Override
-    public Descriptor<ActiveMQAuthenticationMethod> getDescriptor() {
+    public Descriptor<RabbitMQAuthenticationMethod> getDescriptor() {
         return Jenkins.getInstance().getDescriptorByType(SSLCertificateAuthenticationMethodDescriptor.class);
     }
 
@@ -131,7 +151,7 @@ public class SSLCertificateAuthenticationMethod extends ActiveMQAuthenticationMe
 
         @Override
         public SSLCertificateAuthenticationMethod newInstance(StaplerRequest sr, JSONObject jo) {
-            return new SSLCertificateAuthenticationMethod(jo.getString("keystore"), Secret.fromString(jo.getString("keypwd")),
+            return new SSLCertificateAuthenticationMethod(jo.getString("username"),jo.getString("keystore"), Secret.fromString(jo.getString("keypwd")),
                                                           jo.getString("truststore"), Secret.fromString(jo.getString("trustpwd")));
         }
 
@@ -140,7 +160,10 @@ public class SSLCertificateAuthenticationMethod extends ActiveMQAuthenticationMe
         }
 
         @RequirePOST
-        public FormValidation doTestConnection(@QueryParameter("broker") String broker,
+        public FormValidation doTestConnection(@QueryParameter("username") String username,
+                                               @QueryParameter("hostName") String hostName,
+                                               @QueryParameter("portNumber") Integer portNumber,
+                                               @QueryParameter("virtualHost") String virtualHost,
                                                @QueryParameter("keystore") String keystore,
                                                @QueryParameter("keypwd") String keypwd,
                                                @QueryParameter("truststore") String truststore,
@@ -148,36 +171,31 @@ public class SSLCertificateAuthenticationMethod extends ActiveMQAuthenticationMe
 
             checkAdmin();
 
-            broker = StringUtils.strip(StringUtils.stripToNull(broker), "/");
             Connection connection = null;
-            Session session = null;
-            if (broker != null && isValidURL(broker)) {
+            Channel channel = null;
+            try {
+                SSLCertificateAuthenticationMethod sam = new SSLCertificateAuthenticationMethod(username,
+                        keystore, Secret.fromString(keypwd), truststore, Secret.fromString(trustpwd));
+                ConnectionFactory connectionFactory = sam.getConnectionFactory(hostName, portNumber, virtualHost);
+                connection = connectionFactory.newConnection();
+                channel = connection.createChannel();
+                channel.close();
+                connection.close();
+                return FormValidation.ok(Messages.SuccessBrokerConnect(hostName));
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Unhandled exception in SSLCertificateAuthenticationMethod.doTestConnection: ", e);
+                return FormValidation.error(Messages.Error() + ": " + e);
+            } finally {
                 try {
-                    SSLCertificateAuthenticationMethod sam = new SSLCertificateAuthenticationMethod(keystore, Secret.fromString(keypwd), truststore, Secret.fromString(trustpwd));
-                    ActiveMQSslConnectionFactory connectionFactory = sam.getConnectionFactory(broker);
-                    connection = connectionFactory.createConnection();
-                    connection.start();
-                    session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                    session.close();
-                    connection.close();
-                    return FormValidation.ok(Messages.SuccessBrokerConnect(broker));
-                } catch (Exception e) {
-                    log.log(Level.SEVERE, "Unhandled exception in SSLCertificateAuthenticationMethod.doTestConnection: ", e);
-                    return FormValidation.error(Messages.Error() + ": " + e);
-                } finally {
-                    try {
-                        if (session != null) {
-                            session.close();
-                        }
-                        if (connection != null) {
-                            connection.close();
-                        }
-                    } catch (JMSException e) {
-                        //
+                    if (channel != null) {
+                        channel.close();
                     }
+                    if (connection != null) {
+                        connection.close();
+                    }
+                } catch (Exception e) {
+                    //
                 }
-            } else {
-                return FormValidation.error(Messages.InvalidURI());
             }
         }
     }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod.java
@@ -1,13 +1,11 @@
-package com.redhat.jenkins.plugins.ci.authentication.activemq;
+package com.redhat.jenkins.plugins.ci.authentication.rabbitmq;
 
-import com.redhat.jenkins.plugins.ci.Messages;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -15,13 +13,15 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Session;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Channel;
+
 import javax.servlet.ServletException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.redhat.jenkins.plugins.ci.Messages;
 /*
  * The MIT License
  *
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-public class UsernameAuthenticationMethod extends ActiveMQAuthenticationMethod  {
+public class UsernameAuthenticationMethod extends RabbitMQAuthenticationMethod  {
     private static final long serialVersionUID = 452156745621333923L;
     private transient static final Logger log = Logger.getLogger(UsernameAuthenticationMethod.class.getName());
 
@@ -77,12 +77,18 @@ public class UsernameAuthenticationMethod extends ActiveMQAuthenticationMethod  
     }
 
     @Override
-    public ActiveMQConnectionFactory getConnectionFactory(String broker) {
-        return new ActiveMQConnectionFactory(getUsername(), getPassword().getPlainText(), broker);
+    public ConnectionFactory getConnectionFactory(String hostName, Integer portNumber, String virtualHost) {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        connectionFactory.setHost(hostName);
+        connectionFactory.setPort(portNumber);
+        connectionFactory.setVirtualHost(virtualHost);
+        connectionFactory.setUsername(getUsername());
+        connectionFactory.setPassword(getPassword().getPlainText());
+        return connectionFactory;
     }
 
     @Override
-    public Descriptor<ActiveMQAuthenticationMethod> getDescriptor() {
+    public Descriptor<RabbitMQAuthenticationMethod> getDescriptor() {
         return Jenkins.getInstance().getDescriptorByType(UsernameAuthenticationMethodDescriptor.class);
     }
 
@@ -104,42 +110,38 @@ public class UsernameAuthenticationMethod extends ActiveMQAuthenticationMethod  
         }
 
         @RequirePOST
-        public FormValidation doTestConnection(@QueryParameter("broker") String broker,
+        public FormValidation doTestConnection(@QueryParameter("hostName") String hostName,
+                                               @QueryParameter("portNumber") Integer portNumber,
+                                               @QueryParameter("virtualHost") String virtualHost,
                                                @QueryParameter("username") String username,
                                                @QueryParameter("password") String password) throws ServletException {
 
             checkAdmin();
 
-            broker = StringUtils.strip(StringUtils.stripToNull(broker), "/");
-            Session session = null;
             Connection connection = null;
-            if (broker != null && isValidURL(broker)) {
+            Channel channel = null;
+            try {
+                UsernameAuthenticationMethod uam = new UsernameAuthenticationMethod(username, Secret.fromString(password));
+                ConnectionFactory connectionFactory = uam.getConnectionFactory(hostName, portNumber, virtualHost);
+                connection = connectionFactory.newConnection();
+                channel = connection.createChannel();
+                channel.close();
+                connection.close();
+                return FormValidation.ok(Messages.SuccessBrokerConnect(hostName));
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Unhandled exception in UsernameAuthenticationMethod.doTestConnection: ", e);
+                return FormValidation.error(Messages.Error() + ": " + e);
+            } finally {
                 try {
-                    UsernameAuthenticationMethod uam = new UsernameAuthenticationMethod(username, Secret.fromString(password));
-                    ActiveMQConnectionFactory connectionFactory = uam.getConnectionFactory(broker);
-                    connection = connectionFactory.createConnection();
-                    connection.start();
-                    session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                    session.close();
-                    connection.close();
-                    return FormValidation.ok(Messages.SuccessBrokerConnect(broker));
-                } catch (Exception e) {
-                    log.log(Level.SEVERE, "Unhandled exception in UsernameAuthenticationMethod.doTestConnection: ", e);
-                    return FormValidation.error(Messages.Error() + ": " + e);
-                } finally {
-                    try {
-                        if (session != null) {
-                            session.close();
-                        }
-                        if (connection != null) {
-                            connection.close();
-                        }
-                    } catch (JMSException e) {
-                        //
+                    if (channel != null) {
+                        channel.close();
                     }
+                    if (connection != null) {
+                        connection.close();
+                    }
+                } catch (Exception e) {
+                    //
                 }
-            } else {
-                return FormValidation.error(Messages.InvalidURI());
             }
         }
     }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.redhat.jenkins.plugins.ci.authentication.AuthenticationMethod.AuthenticationMethodDescriptor;
+import com.redhat.jenkins.plugins.ci.authentication.activemq.ActiveMQAuthenticationMethod.AuthenticationMethodDescriptor;
 import com.redhat.jenkins.plugins.ci.authentication.activemq.ActiveMQAuthenticationMethod;
 import com.redhat.jenkins.plugins.ci.authentication.activemq.UsernameAuthenticationMethod;
 import com.redhat.jenkins.plugins.ci.messaging.topics.DefaultTopicProvider;

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessageProviderMigrator.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessageProviderMigrator.java
@@ -1,5 +1,6 @@
 package com.redhat.jenkins.plugins.ci.messaging;
 
+import com.redhat.jenkins.plugins.ci.provider.data.*;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -18,10 +19,6 @@ import com.redhat.jenkins.plugins.ci.CIMessageBuilder;
 import com.redhat.jenkins.plugins.ci.CIMessageNotifier;
 import com.redhat.jenkins.plugins.ci.CIMessageSubscriberBuilder;
 import com.redhat.jenkins.plugins.ci.GlobalCIConfiguration;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQSubscriberProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData;
 
 /*
  * The MIT License
@@ -71,12 +68,18 @@ public class MessageProviderMigrator {
                 apd.setMessageContent(builder.getMessageContent());
                 apd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(apd);
-            } else {
+            } else if (prov instanceof FedMsgMessagingProvider) {
                 FedMsgPublisherProviderData fpd = new FedMsgPublisherProviderData(builder.getProviderName());
                 fpd.setOverrides(builder.getOverrides());
                 fpd.setMessageContent(builder.getMessageContent());
                 fpd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(fpd);
+            } else {
+                RabbitMQPublisherProviderData rpd = new RabbitMQPublisherProviderData(builder.getProviderName());
+                rpd.setOverrides(builder.getOverrides());
+                rpd.setMessageContent(builder.getMessageContent());
+                rpd.setFailOnError(builder.isFailOnError());
+                builder.setProviderData(rpd);
             }
             try {
                 p.save();
@@ -108,12 +111,18 @@ public class MessageProviderMigrator {
                 apd.setMessageContent(builder.getMessageContent());
                 apd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(apd);
-            } else {
+            } else if (prov instanceof FedMsgMessagingProvider) {
                 FedMsgPublisherProviderData fpd = new FedMsgPublisherProviderData(builder.getProviderName());
                 fpd.setOverrides(builder.getOverrides());
                 fpd.setMessageContent(builder.getMessageContent());
                 fpd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(fpd);
+            } else {
+                RabbitMQPublisherProviderData rpd = new RabbitMQPublisherProviderData(builder.getProviderName());
+                rpd.setOverrides(builder.getOverrides());
+                rpd.setMessageContent(builder.getMessageContent());
+                rpd.setFailOnError(builder.isFailOnError());
+                builder.setProviderData(rpd);
             }
             try {
                 p.save();
@@ -144,12 +153,18 @@ public class MessageProviderMigrator {
                 apd.setVariable(builder.getVariable());
                 apd.setTimeout(builder.getTimeout());
                 builder.setProviderData(apd);
-            } else {
+            } else if (prov instanceof FedMsgMessagingProvider) {
                 FedMsgSubscriberProviderData fpd = new FedMsgSubscriberProviderData(builder.getProviderName());
                 fpd.setOverrides(builder.getOverrides());
                 fpd.setVariable(builder.getVariable());
                 fpd.setTimeout(builder.getTimeout());
                 builder.setProviderData(fpd);
+            } else {
+                RabbitMQSubscriberProviderData rpd = new RabbitMQSubscriberProviderData(builder.getProviderName());
+                rpd.setOverrides(builder.getOverrides());
+                rpd.setVariable(builder.getVariable());
+                rpd.setTimeout(builder.getTimeout());
+                builder.setProviderData(rpd);
             }
             try {
                 p.save();

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessagingProviderOverrides.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessagingProviderOverrides.java
@@ -16,6 +16,7 @@ public class MessagingProviderOverrides implements Describable<MessagingProvider
     private static final long serialVersionUID = -8815444484948038651L;
 
     private String topic;
+    private String queue;
 
     @Whitelisted
     @DataBoundConstructor
@@ -27,9 +28,19 @@ public class MessagingProviderOverrides implements Describable<MessagingProvider
         return topic;
     }
 
+
+    public String getQueue() {
+        return queue;
+    }
+
     @DataBoundSetter
     public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+    @DataBoundSetter
+    public void setQueue(String queue) {
+        this.queue = queue;
     }
 
     @Override
@@ -39,7 +50,8 @@ public class MessagingProviderOverrides implements Describable<MessagingProvider
 
         MessagingProviderOverrides that = (MessagingProviderOverrides) o;
 
-        return topic != null ? topic.equals(that.topic) : that.topic == null;
+        return (topic != null ? topic.equals(that.topic) : that.topic == null) &&
+                (queue != null ? queue.equals(that.queue) : that.queue == null);
     }
 
     @Override

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider.java
@@ -1,16 +1,71 @@
 package com.redhat.jenkins.plugins.ci.messaging;
 
-import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQProviderData;
 import hudson.Extension;
+import hudson.ExtensionList;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.logging.Logger;
 
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Connection;
+
+import com.redhat.jenkins.plugins.ci.authentication.rabbitmq.RabbitMQAuthenticationMethod.AuthenticationMethodDescriptor;
+import com.redhat.jenkins.plugins.ci.authentication.rabbitmq.RabbitMQAuthenticationMethod;
+import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQProviderData;
+
 public class RabbitMQMessagingProvider extends JMSMessagingProvider {
 
+    private static final long serialVersionUID = 82154526798596907L;
+
     private static final Logger log = Logger.getLogger(RabbitMQMessagingProvider.class.getName());
+
+    private String virtualHost;
+    private String hostName;
+    private Integer portNumber;
+    private RabbitMQAuthenticationMethod authenticationMethod;
+    private Connection connection;
+    private String exchange;
+    private String queue;
+
+    @DataBoundConstructor
+    public RabbitMQMessagingProvider(String name, String virtualHost,
+                                     String hostName, Integer portNumber,
+                                     String topic, String exchange, String queue,
+                                     RabbitMQAuthenticationMethod authenticationMethod) {
+        this.name = name;
+        this.virtualHost = virtualHost;
+        this.hostName = hostName;
+        this.portNumber = portNumber;
+        this.topic = topic;
+        this.exchange = exchange;
+        this.queue = queue;
+        this.authenticationMethod = authenticationMethod;
+    }
+
+    public String getVirtualHost() { return virtualHost; }
+
+    public String getHostName() { return hostName; }
+
+    public Integer getPortNumber() { return portNumber; }
+
+    public String getTopic() { return topic; }
+
+    public String getExchange() { return exchange; }
+
+    public String getQueue() { return queue; }
+
+    public Connection getConnection() { return connection; }
+
+    public void setConnection(Connection connection) { this.connection = connection; }
+
+    public RabbitMQAuthenticationMethod getAuthenticationMethod() { return authenticationMethod; }
+
+    public ConnectionFactory getConnectionFactory() {
+        return authenticationMethod.getConnectionFactory(getHostName(), getPortNumber(), getVirtualHost());
+    }
 
     @Override
     public JMSMessagingWorker createWorker(ProviderData pdata, String jobname) {
@@ -34,5 +89,8 @@ public class RabbitMQMessagingProvider extends JMSMessagingProvider {
             return "RabbitMQ";
         }
 
+        public ExtensionList<AuthenticationMethodDescriptor> getAuthenticationMethodDescriptors() {
+            return AuthenticationMethodDescriptor.all();
+        }
     }
 }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
@@ -1,10 +1,32 @@
 package com.redhat.jenkins.plugins.ci.messaging;
 
+import com.rabbitmq.client.*;
+import com.redhat.jenkins.plugins.ci.CIEnvironmentContributingAction;
+import com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck;
+import com.redhat.jenkins.plugins.ci.messaging.data.RabbitMQMessage;
 import com.redhat.jenkins.plugins.ci.messaging.data.SendResult;
 import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQPublisherProviderData;
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQSubscriberProviderData;
+import com.redhat.utils.PluginUtils;
+import hudson.EnvVars;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class RabbitMQMessagingWorker extends JMSMessagingWorker {
@@ -12,48 +34,399 @@ public class RabbitMQMessagingWorker extends JMSMessagingWorker {
     private static final Logger log = Logger.getLogger(RabbitMQMessagingWorker.class.getName());
     private final RabbitMQMessagingProvider provider;
 
+    private Connection connection;
+    private Channel channel;
+    // Thread interruption flag
+    private boolean interrupt = false;
+    private String uuid = UUID.randomUUID().toString();
+    // Concurrent message queue used for saving messages from consumer
+    private ConcurrentLinkedQueue<RabbitMQMessage> messageQueue = new ConcurrentLinkedQueue<RabbitMQMessage>();
+    private String consumerTag = "";
+    private String queueName = "";
+    private String exchangeName = "";
+
     public RabbitMQMessagingWorker(JMSMessagingProvider messagingProvider, MessagingProviderOverrides overrides, String jobname) {
         super(messagingProvider, overrides, jobname);
         this.provider = (RabbitMQMessagingProvider) messagingProvider;
+        this.connection = provider.getConnection();
+        this.exchangeName = provider.getExchange();
+        this.queueName = provider.getQueue();
+        this.topic = getTopic(provider);
     }
 
     @Override
     public boolean subscribe(String jobname, String selector) {
+        if (interrupt) {
+            return true;
+        }
+        if (this.topic != null) {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    if (connection == null || !connection.isOpen()) {
+                        if (!connect()) {
+                            return false;
+                        }
+                    }
+                    if (channel == null) {
+                        this.channel = connection.createChannel();
+                        log.info("Subscribing job '" + jobname + "' to " + this.topic + " topic.");
+                        channel.exchangeDeclarePassive(exchangeName);
+                        String queueName = getQueue(provider);
+                        channel.queueBind(queueName, exchangeName, this.topic);
+
+                        // Create deliver callback to listen for messages
+                        DeliverCallback deliverCallback = (consumerTag, delivery) -> {
+                            String json = new String(delivery.getBody(), "UTF-8");
+                            log.info(
+                                    "Received '" + delivery.getEnvelope().getRoutingKey() + "':\n" + "Message id: '" + delivery.getProperties().getMessageId() + "'\n'" + json + "'");
+                            RabbitMQMessage message = new RabbitMQMessage(delivery.getEnvelope().getRoutingKey(), json, delivery.getProperties().getMessageId());
+                            message.setTimestamp(new Date().getTime());
+                            message.setDeliveryTag(delivery.getEnvelope().getDeliveryTag());
+                            messageQueue.add(message);
+
+                        };
+                        this.consumerTag = channel.basicConsume(queueName, deliverCallback, (CancelCallback) null);
+                        log.info("Successfully subscribed job '" + jobname + "' to topic '" + this.topic + "'.");
+                    } else {
+                        log.info("Already subscribed job '" + jobname + "' to topic '" + this.topic + "'.");
+                    }
+                    return true;
+                } catch (Exception ex) {
+
+                    // Either we were interrupted, or something else went
+                    // wrong. If we were interrupted, then we will jump ship
+                    // on the next iteration. If something else happened,
+                    // then we just unsubscribe here, sleep, so that we may
+                    // try again on the next iteration.
+
+                    log.log(Level.SEVERE, "Eexception raised while subscribing job '" + jobname + "', retrying in " + RETRY_MINUTES + " minutes.", ex);
+                    if (!Thread.currentThread().isInterrupted()) {
+
+                        unsubscribe(jobname);
+
+                        try {
+                            Thread.sleep(RETRY_MINUTES * 60 * 1000);
+                        } catch (InterruptedException ie) {
+                            // We were interrupted while waiting to retry.
+                            // We will jump ship on the next iteration.
+
+                            // NB: The interrupt flag was cleared when
+                            // InterruptedException was thrown. We have to
+                            // re-install it to make sure we eventually
+                            // leave this thread.
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                }
+            }
+        }
         return false;
     }
 
     @Override
     public void unsubscribe(String jobname) {
+        if (interrupt) {
+            log.info("We are being interrupted. Skipping unsubscribe...");
+            return;
+        }
+        try {
+            channel.basicCancel(consumerTag);
+            channel.close();
+        } catch (Exception ex) {
+            log.warning("Exception occurred when closing channel: " + ex.getMessage());
+        }
 
     }
 
     @Override
     public void receive(String jobname, ProviderData pdata) {
+        RabbitMQSubscriberProviderData pd = (RabbitMQSubscriberProviderData) pdata;
+        Integer timeout = (pd.getTimeout() != null ? pd.getTimeout() : RabbitMQSubscriberProviderData.DEFAULT_TIMEOUT_IN_MINUTES) * 60 * 1000;
 
+        if (interrupt) {
+            log.info("we have been interrupted at start of receive");
+            return;
+        }
+
+        // subscribe job
+        while (!subscribe(jobname)) {
+            if (!Thread.currentThread().isInterrupted()) {
+                try {
+                    int WAIT_SECONDS = 2;
+                    Thread.sleep(WAIT_SECONDS * 1000);
+                } catch (InterruptedException e) {
+                    // We were interrupted while waiting to retry. We will
+                    // jump ship on the next iteration.
+
+                    // NB: The interrupt flag was cleared when
+                    // InterruptedException was thrown. We have to
+                    // re-install it to make sure we eventually leave this
+                    // thread.
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        long lastSeenMessage = new Date().getTime();
+
+        try {
+            while ((new Date().getTime() - lastSeenMessage) < timeout) {
+                if (!messageQueue.isEmpty()) {
+                    RabbitMQMessage data = messageQueue.poll();
+                    // Reset timer
+                    lastSeenMessage = data.getTimestamp().getTime();
+                    //
+                    if (provider.verify(data.getBodyJson(), pd.getChecks(), jobname)) {
+                        Map<String, String> params = new HashMap<String, String>();
+                        params.put("CI_MESSAGE", data.toJson());
+                        trigger(jobname, data.getBodyJson(), params);
+                    }
+                    channel.basicAck(data.getDeliveryTag(), false);
+                } else {
+                    if (interrupt) {
+                        log.info("We have been interrupted...");
+                        break;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            if (!Thread.currentThread().isInterrupted()) {
+                // Something other than an interrupt causes this.
+                // Unsubscribe, but stay in our loop and try to reconnect..
+                log.log(Level.WARNING, "JMS exception raised, going to re-subscribe for job '" + jobname + "'.", e);
+                unsubscribe(jobname); // Try again next time.
+            }
+        }
     }
 
     @Override
-    public boolean connect() throws Exception {
-        return false;
+    public boolean connect() {
+        ConnectionFactory connectionFactory = provider.getConnectionFactory();
+        Connection connectiontmp = null;
+        try {
+            connectiontmp = connectionFactory.newConnection();
+            String url = "";
+            if (Jenkins.getInstanceOrNull() != null) {
+                url = Jenkins.get().getRootUrl();
+            }
+            connectiontmp.setId(provider.getName() + "_" + url + "_" + uuid + "_" + jobname);
+        } catch (Exception e) {
+            log.severe("Unable to connect to " + provider.getHostName() + ":" + provider.getPortNumber() + " " + e.getMessage());
+            return false;
+        }
+        log.info("Connection created");
+        connection = connectiontmp;
+        provider.setConnection(connection);
+        return true;
     }
 
     @Override
     public void disconnect() {
-
+        try {
+            channel.close();
+        } catch (Exception ex) {
+            log.warning("Exception occurred when closing channel: " + ex.getMessage());
+        }
+        try {
+            connection.close();
+        } catch (Exception ex) {
+            log.warning("Exception occurred when closing connection: " + ex.getMessage());
+        }
     }
 
     @Override
     public SendResult sendMessage(Run<?, ?> build, TaskListener listener, ProviderData pdata) {
-        return null;
+        RabbitMQPublisherProviderData pd = (RabbitMQPublisherProviderData)pdata;
+        try {
+            if (connection == null || !connection.isOpen()) {
+                connect();
+            }
+            if (channel == null) {
+                this.channel = connection.createChannel();
+                log.info("Channel created.");
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        String body = "";
+        String msgId = "";
+        try {
+
+            EnvVars env = new EnvVars();
+            env.putAll(build.getEnvironment(listener));
+            env.put("CI_NAME", build.getParent().getName());
+            if (!build.isBuilding()) {
+                env.put("CI_STATUS", (build.getResult() == Result.SUCCESS ? "passed" : "failed"));
+                env.put("BUILD_STATUS", build.getResult().toString());
+            }
+
+            RabbitMQMessage msg = new RabbitMQMessage(PluginUtils.getSubstitutedValue(getTopic(provider), build.getEnvironment(listener)),
+                                                     PluginUtils.getSubstitutedValue(pd.getMessageContent(), env));
+
+            msg.setTimestamp(System.currentTimeMillis());
+
+            body = msg.getBodyJson();
+            msgId = msg.getMsgId();
+            try {
+                channel.exchangeDeclarePassive(exchangeName);
+                channel.basicPublish(exchangeName, msg.getTopic(),
+                        new AMQP.BasicProperties.Builder()
+                        .messageId(msgId).build(), body.getBytes());
+            } catch (IOException e) {
+                if (pd.isFailOnError()) {
+                    log.severe("Unhandled exception in perform: Failed to send message!");
+                    return new SendResult(false, msgId, body);
+                }
+            }
+            log.fine("JSON message:\n" + msg.toJson());
+            listener.getLogger().println("Message id: " + msg.getMsgId());
+            listener.getLogger().println("Message topic: " + msg.getTopic());
+            listener.getLogger().println("JSON message body:\n" + body);
+
+        } catch (Exception e) {
+            if (pd.isFailOnError()) {
+                log.severe("Unhandled exception in perform: ");
+                log.severe(ExceptionUtils.getStackTrace(e));
+                listener.fatalError("Unhandled exception in perform: ");
+                listener.fatalError(ExceptionUtils.getStackTrace(e));
+                return new SendResult(false, msgId, body);
+            } else {
+                log.warning("Unhandled exception in perform: ");
+                log.warning(ExceptionUtils.getStackTrace(e));
+                listener.error("Unhandled exception in perform: ");
+                listener.error(ExceptionUtils.getStackTrace(e));
+                return new SendResult(true, msgId, body);
+            }
+        } finally {
+            try {
+                channel.close();
+            } catch (Exception e) {
+                log.warning("Unhandled exception when closing channel: ");
+                log.warning(ExceptionUtils.getStackTrace(e));
+                listener.getLogger().println("exception in finally");
+            }
+        }
+        return new SendResult(true, msgId, body);
     }
 
     @Override
     public String waitForMessage(Run<?, ?> build, TaskListener listener, ProviderData pdata) {
+        RabbitMQSubscriberProviderData pd = (RabbitMQSubscriberProviderData)pdata;
+
+        try {
+            if (connection == null || !connection.isOpen()) {
+                connect();
+            }
+            if (channel == null) {
+                this.channel = connection.createChannel();
+            }
+            channel.exchangeDeclarePassive(exchangeName);
+            channel.queueBind(getQueue(provider), exchangeName, this.topic);
+        } catch (Exception ex) {
+            log.severe("Connection to broker can't be established!");
+            log.severe(ExceptionUtils.getStackTrace(ex));
+            listener.error("Connection to broker can't be established!");
+            listener.error(ExceptionUtils.getStackTrace(ex));
+            return null;
+        }
+
+        log.info("Waiting for message.");
+        listener.getLogger().println("Waiting for message.");
+        for (MsgCheck msgCheck: pd.getChecks()) {
+            log.info(" with check: " + msgCheck.toString());
+            listener.getLogger().println(" with check: " + msgCheck.toString());
+        }
+        Integer timeout = (pd.getTimeout() != null ? pd.getTimeout() : RabbitMQSubscriberProviderData.DEFAULT_TIMEOUT_IN_MINUTES);
+        log.info(" with timeout: " + timeout + " minutes");
+        listener.getLogger().println(" with timeout: " + timeout + " minutes");
+
+
+        // Create deliver callback to listen for messages
+        DeliverCallback deliverCallback = (consumerTag, delivery) -> {
+            String json = new String(delivery.getBody(), "UTF-8");
+            listener.getLogger().println(
+                    "Received '" + delivery.getEnvelope().getRoutingKey() + "':\n" + "Message id: '" + delivery.getProperties().getMessageId() + "'\n'" + json + "'");
+            log.info(
+                    "Received '" + delivery.getEnvelope().getRoutingKey() + "':\n" + "Message id: '" + delivery.getProperties().getMessageId() + "'\n'" + json + "'");
+            RabbitMQMessage message = new RabbitMQMessage(delivery.getEnvelope().getRoutingKey(), json, delivery.getProperties().getMessageId());
+            message.setTimestamp(new Date().getTime());
+            message.setDeliveryTag(delivery.getEnvelope().getDeliveryTag());
+            messageQueue.add(message);
+
+        };
+
+        String consumerTag = null;
+
+        long startTime = new Date().getTime();
+
+        int timeoutInMs = timeout * 60 * 1000;
+
+        try {
+            consumerTag = channel.basicConsume(getQueue(provider), deliverCallback, (CancelCallback) null);
+            while ((new Date().getTime() - startTime) < timeoutInMs) {
+                if (!messageQueue.isEmpty()) {
+
+                    RabbitMQMessage message = messageQueue.poll();
+                    log.info("Obtained message from queue: " + message.toJson());
+
+                    if (!provider.verify(message.getBodyJson(), pd.getChecks(), jobname)) {
+                        channel.basicAck(message.getDeliveryTag(), false);
+                        continue;
+                    }
+                    listener.getLogger().println(
+                            "Message: '" + message.getMsgId() + "' was succesfully checked.");
+
+                    if (build != null) {
+                        if (StringUtils.isNotEmpty(pd.getVariable())) {
+                            EnvVars vars = new EnvVars();
+                            vars.put(pd.getVariable(), message.getBodyJson());
+                            build.addAction(new CIEnvironmentContributingAction(vars));
+                        }
+                    }
+                    channel.basicAck(message.getDeliveryTag(), false);
+                    return message.getBodyJson();
+                }
+                if (interrupt) {
+                    return null;
+                }
+                TimeUnit.SECONDS.sleep(1);
+            }
+            log.severe("Timed out waiting for message!");
+            listener.getLogger().println("Timed out waiting for message!");
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "Unhandled exception waiting for message.", e);
+        } finally {
+            try {
+                if (consumerTag != null) {
+                    channel.basicCancel(consumerTag);
+                }
+                channel.close();
+            } catch (Exception e) {
+                listener.getLogger().println("exception in finally");
+            }
+        }
         return null;
+    }
+
+    public void prepareForInterrupt() {
+        interrupt = true;
     }
 
     @Override
     public String getDefaultTopic() {
         return null;
+    }
+
+    protected String getQueue(JMSMessagingProvider provider) {
+        String ltopic;
+        RabbitMQMessagingProvider providerd = (RabbitMQMessagingProvider) provider;
+        if (overrides != null && overrides.getQueue() != null && !overrides.getQueue().isEmpty()) {
+            ltopic = overrides.getQueue();
+        } else if (providerd.getQueue() != null && !providerd.getQueue().isEmpty()) {
+            ltopic = providerd.getQueue();
+        } else {
+            ltopic = queueName;
+        }
+        return PluginUtils.getSubstitutedValue(ltopic, null);
     }
 }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/data/RabbitMQMessage.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/data/RabbitMQMessage.java
@@ -1,0 +1,167 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.redhat.jenkins.plugins.ci.messaging.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder(
+        alphabetic = true
+)
+public class RabbitMQMessage {
+
+    private static final Logger log = Logger.getLogger(RabbitMQMessage.class.getName());
+
+    private long timestamp;
+    private String topic;
+    private String msgId;
+    private long deliveryTag;
+    @JsonProperty("msg")
+    private Map<String, Object> msg = null;
+
+    public RabbitMQMessage() {}
+
+    public RabbitMQMessage(String topic) {
+        this(topic, null, null);
+    }
+
+    public RabbitMQMessage(String topic, String body) {
+        this(topic, body, null);
+    }
+
+    public RabbitMQMessage(String topic, String body, String msgId) {
+        this.topic = topic;
+        if (msgId != null) {
+            this.msgId = msgId;
+        }
+        else {
+            this.msgId = Integer.toString(Calendar.getInstance().get(1)) + "-" + UUID.randomUUID().toString();
+        }
+
+        if (!StringUtils.isBlank(body)) {
+            try {
+                log.fine("Message to deserialize: '" + body + "'");
+                ObjectMapper mapper = new ObjectMapper();
+                TypeReference<HashMap<String,Object>> typeRef = new TypeReference<HashMap<String,Object>>() {};
+                msg = mapper.readValue(body, typeRef);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Unable to deserialize message body.", e);
+            }
+        }
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public Date getTimestamp() {
+        return new Date(this.timestamp);
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public long getDeliveryTag() { return deliveryTag; }
+
+    public void setDeliveryTag(long deliveryTag) { this.deliveryTag = deliveryTag; }
+
+    @JsonProperty("msg_id")
+    public final String getMsgId() {
+        return this.msgId;
+    }
+
+    public Map<String, Object> getMsg() {
+        return msg;
+    }
+
+    public void setMsg(Map<String, Object> msg) {
+        this.msg = msg;
+    }
+
+    @JsonIgnore
+    public String getBodyJson() {
+        if (msg != null) {
+            return JSONObject.fromObject(msg).toString();
+        }
+        return "";
+    }
+
+    public String toJson() {
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectWriter writer = mapper.writer();
+            writer.with(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS).writeValue(os, this);
+            os.close();
+            return new String(os.toByteArray(), "UTF-8");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/pipeline/CIMessageSenderStep.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/pipeline/CIMessageSenderStep.java
@@ -1,5 +1,6 @@
 package com.redhat.jenkins.plugins.ci.pipeline;
 
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQPublisherProviderData;
 import com.redhat.utils.MessageUtils;
 import hudson.Extension;
 import hudson.Launcher;
@@ -184,6 +185,12 @@ public class CIMessageSenderStep extends Step {
                             fpd.setMessageContent(step.getMessageContent());
                             fpd.setFailOnError(step.getFailOnError());
                             pd = fpd;
+                        } else {
+                            RabbitMQPublisherProviderData rpd = new RabbitMQPublisherProviderData(step.getProviderName());
+                            rpd.setOverrides(step.getOverrides());
+                            rpd.setMessageContent(step.getMessageContent());
+                            rpd.setFailOnError(step.getFailOnError());
+                            pd = rpd;
                         }
                         CIMessageNotifier notifier = new CIMessageNotifier(pd);
                         StepContext c = getContext();

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData.java
@@ -40,8 +40,6 @@ import org.kohsuke.stapler.StaplerRequest;
 public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
     private static final long serialVersionUID = -2179136605130421113L;
 
-    private MESSAGE_TYPE messageType;
-    private String messageProperties;
     private String messageContent;
     private Boolean failOnError = false;
 
@@ -67,30 +65,10 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
         super(name, overrides);
     }
 
-    public RabbitMQPublisherProviderData(String name, MessagingProviderOverrides overrides, MESSAGE_TYPE messageType, String messageProperties, String messageContent, Boolean failOnError) {
+    public RabbitMQPublisherProviderData(String name, MessagingProviderOverrides overrides, String messageContent, Boolean failOnError) {
         this(name, overrides);
-        this.messageType = messageType;
-        this.messageProperties = messageProperties;
         this.messageContent = messageContent;
         this.failOnError = failOnError;
-    }
-
-    public MESSAGE_TYPE getMessageType() {
-        return messageType;
-    }
-
-    @DataBoundSetter
-    public void setMessageType(MESSAGE_TYPE messageType) {
-        this.messageType = messageType;
-    }
-
-    public String getMessageProperties() {
-        return messageProperties;
-    }
-
-    @DataBoundSetter
-    public void setMessageProperties(String messageProperties) {
-        this.messageProperties = messageProperties;
     }
 
     public String getMessageContent() {
@@ -125,8 +103,6 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
         RabbitMQPublisherProviderData thatp = (RabbitMQPublisherProviderData)that;
         return (this.name != null ? this.name.equals(thatp.name) : thatp.name == null) &&
                (this.overrides != null ? this.overrides.equals(thatp.overrides) : thatp.overrides == null) &&
-               (this.messageType != null ? this.messageType.equals(thatp.messageType) : thatp.messageType == null) &&
-               (this.messageProperties != null ? this.messageProperties.equals(thatp.messageProperties) : thatp.messageProperties == null) &&
                (this.messageContent != null ? this.messageContent.equals(thatp.messageContent) : thatp.messageContent == null) &&
                (this.failOnError != null ? this.failOnError.equals(thatp.failOnError) : thatp.failOnError == null);
     }
@@ -149,8 +125,6 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
             return new RabbitMQPublisherProviderData(
                     jo.getString("name"),
                     mpo,
-                    MESSAGE_TYPE.fromString(jo.getString("messageType")),
-                    jo.getString("messageProperties"),
                     jo.getString("messageContent"),
                     jo.getBoolean("failOnError"));
         }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData.java
@@ -46,7 +46,6 @@ public class RabbitMQSubscriberProviderData extends RabbitMQProviderData {
     public static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
     public static final Integer DEFAULT_TIMEOUT_IN_MINUTES = 60;
 
-    private String selector;
     private List<MsgCheck> checks = new ArrayList<MsgCheck>();
     private String variable;
     private Integer timeout = DEFAULT_TIMEOUT_IN_MINUTES;
@@ -72,22 +71,13 @@ public class RabbitMQSubscriberProviderData extends RabbitMQProviderData {
         super(name, overrides);
     }
 
-    public RabbitMQSubscriberProviderData(String name, MessagingProviderOverrides overrides, String selector, List<MsgCheck> checks, String variable, Integer timeout) {
+    public RabbitMQSubscriberProviderData(String name, MessagingProviderOverrides overrides, List<MsgCheck> checks, String variable, Integer timeout) {
         this(name, overrides);
-        this.selector = selector;
         this.checks = checks;
         this.variable = variable;
         this.timeout = timeout;
     }
 
-    public String getSelector() {
-        return selector;
-    }
-
-    @DataBoundSetter
-    public void setSelector(String selector) {
-        this.selector = selector;
-    }
 
     public List<MsgCheck> getChecks() {
         return checks;
@@ -129,7 +119,6 @@ public class RabbitMQSubscriberProviderData extends RabbitMQProviderData {
 
         RabbitMQSubscriberProviderData thatp = (RabbitMQSubscriberProviderData)that;
         return (this.name != null ? this.name.equals(thatp.name) : thatp.name == null) &&
-               (this.selector != null ? this.selector.equals(thatp.selector) : thatp.selector == null) &&
                (this.overrides != null ? this.overrides.equals(thatp.overrides) : thatp.overrides == null) &&
                (this.checks != null ? this.checks.equals(thatp.checks) : thatp.checks == null) &&
                (this.variable != null ? this.variable.equals(thatp.variable) : thatp.variable == null) &&
@@ -150,6 +139,7 @@ public class RabbitMQSubscriberProviderData extends RabbitMQProviderData {
             MessagingProviderOverrides mpo = null;
             if (!jo.getJSONObject("overrides").isNullObject()) {
                 mpo = new MessagingProviderOverrides(jo.getJSONObject("overrides").getString("topic"));
+                mpo.setQueue(jo.getJSONObject("overrides").getString("queue"));
             }
             List<MsgCheck> checks = sr.bindJSONToList(MsgCheck.class, jo.get("checks"));
             String variable = null;
@@ -160,7 +150,7 @@ public class RabbitMQSubscriberProviderData extends RabbitMQProviderData {
             if (jo.has("timeout") && !StringUtils.isEmpty(jo.getString("timeout"))) {
                 timeout = jo.getInt("timeout");
             }
-            return new RabbitMQSubscriberProviderData(jo.getString("name"), mpo, jo.getString("selector"), checks, variable, timeout);
+            return new RabbitMQSubscriberProviderData(jo.getString("name"), mpo, checks, variable, timeout);
         }
 
         public String getDefaultVariable() {

--- a/src/main/java/com/redhat/jenkins/plugins/ci/threads/RabbitMqTriggerThread.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/threads/RabbitMqTriggerThread.java
@@ -2,11 +2,30 @@ package com.redhat.jenkins.plugins.ci.threads;
 
 import com.redhat.jenkins.plugins.ci.CIBuildTrigger;
 import com.redhat.jenkins.plugins.ci.messaging.JMSMessagingProvider;
+import com.redhat.jenkins.plugins.ci.messaging.RabbitMQMessagingWorker;
 import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class RabbitMqTriggerThread extends CITriggerThread {
+    private static final Logger log = Logger.getLogger(RabbitMqTriggerThread.class.getName());
+
+    private RabbitMQMessagingWorker worker;
 
     public RabbitMqTriggerThread(JMSMessagingProvider messagingProvider, ProviderData providerData, String jobname, CIBuildTrigger cibt, int instance) {
         super(messagingProvider, providerData, jobname, cibt, instance);
+        worker = (RabbitMQMessagingWorker)messagingWorker;
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            worker.prepareForInterrupt();
+            interrupt();
+            join();
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Unhandled exception in RabbitMQ trigger stop.", e);
+        }
     }
 }

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keypwd.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keypwd.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Key store file password.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keystore.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keystore.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Key store file to use to connect to the CI topic.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-trustpwd.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-trustpwd.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Trust store file password.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-truststore.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-truststore.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Trust store file to use to connect to the CI topic.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-username.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-username.html
@@ -1,0 +1,3 @@
+<div>
+  <p>User name to use to connect to the CI exchange. Should be same as in provided certificates.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/sslcert.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/sslcert.jelly
@@ -1,0 +1,46 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+      <f:nested>
+        <f:entry title="${%User name}" field="username">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Key store}" field="keystore">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Key store password}" field="keypwd">
+          <f:password />
+        </f:entry>
+        <f:entry title="${%Trust store}" field="truststore">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Trust store password}" field="trustpwd">
+          <f:password />
+        </f:entry>
+        <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection"
+         with="hostName,portNumber,virtualHost,keystore,keypwd,truststore,trustpwd" />
+      </f:nested>
+</j:jelly>
+

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-password.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-password.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Password to use to connect to the CI exchange.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-username.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-username.html
@@ -1,0 +1,3 @@
+<div>
+  <p>User name to use to connect to the CI exchange.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/username.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/username.jelly
@@ -1,0 +1,37 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+      <f:nested>
+        <f:entry title="${%User name}" field="username">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Password}" field="password">
+          <f:password />
+        </f:entry>
+        <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection"
+         with="hostName,portNumber,virtualHost,username,password" />
+      </f:nested>
+</j:jelly>
+

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/config.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/config.jelly
@@ -1,0 +1,54 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+    <?jelly escape-by-default='true'?>
+    <f:section title="Connection Properties">
+    <f:entry title="Name" field="name">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Host Name}" field="hostName">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Port Number}" field="portNumber">
+      <f:number />
+    </f:entry>
+    <f:entry title="${%Virtual Host}" field="virtualHost">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Topic}" field="topic">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Exchange}" field="exchange">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Queue}" field="queue">
+      <f:textbox />
+    </f:entry>
+    <f:dropdownDescriptorSelector title="${%Authentication Method}"
+                                  field="authenticationMethod"
+                                  descriptors="${descriptor.getAuthenticationMethodDescriptors()}" />
+ </f:section>
+</j:jelly>
+

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-authenticationMethod.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-authenticationMethod.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Authentication method to use when connecting to RabbitMQ server.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-exchange.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-exchange.html
@@ -1,0 +1,3 @@
+<div>
+  <p>RabbitMQ exchange to use for this provider.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-hostName.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-hostName.html
@@ -1,0 +1,3 @@
+<div>
+  <p>RabbiMQ server hostname.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-name.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-name.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Name of the provider.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-portNumber.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-portNumber.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Port where RabbitMQ server is listening.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-queue.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-queue.html
@@ -1,0 +1,7 @@
+<div>
+  <p>Global queue used for RabbitMQ messages.</p>
+
+  <p>This queue is for notifier as default.</p>
+
+  <p>Could be overridden in configuration of specific notifier.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-topic.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-topic.html
@@ -1,0 +1,7 @@
+<div>
+  <p>Global topic used for RabbitMQ messages.</p>
+
+  <p>This topic is used both for subscriber and notifier as default.</p>
+
+  <p>Could be overridden in configuration of specific subscriber or notifier.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-virtualHost.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-virtualHost.html
@@ -1,0 +1,3 @@
+<div>
+  <p>RabbiMQ server virtual host.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/RabbitMQPublisherProviderDataDescriptor/rabbitmq-publisher.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/RabbitMQPublisherProviderDataDescriptor/rabbitmq-publisher.jelly
@@ -1,0 +1,54 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:rh="/com/redhat/jenkins/plugins/ci/CIMessageSubscriberBuilder/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+  <f:nested>
+    <j:choose>
+      <j:when test="${empty(instance)}">
+        <j:set var="checked" value="${pdata.hasOverrides();}"/>
+        <j:set var="value" value="${pdata.getPublisherTopic();}"/>
+        <j:set var="name" value="${pdata.getName();}"/>
+      </j:when>
+      <j:otherwise>
+        <j:set var="checked" value="${instance.getOverrides() != null}"/>
+        <j:set var="value" value="${instance.getOverrides().getTopic();}"/>
+        <j:set var="name" value="${instance.getName();}"/>
+      </j:otherwise>
+    </j:choose>
+    <table width="100%">
+      <f:optionalBlock field="overrides" title="Override provider topic" checked="${checked}">
+        <f:entry title="${%Topic name}" field="topic">
+          <f:textbox value="${value}"/>
+        </f:entry>
+      </f:optionalBlock>
+    </table>
+  </f:nested>
+  <f:entry title="${%Message content}" field="messageContent">
+    <f:textarea name="messageContent"/>
+  </f:entry>
+  <f:entry field="failOnError">
+    <f:checkbox title="${%Fail on error}" name="failOnError" default="false"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-failOnError.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-failOnError.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Whether you want to fail the build if there is an error sending a message. By default, it is false.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-messageContent.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-messageContent.html
@@ -1,0 +1,5 @@
+<div>
+  <p>Content of CI message to be sent. Environment variable values may be used in the content to allow customization
+     of the message. Environment variables should use the familiar bash shell format, e.g. ${VARIABLE}.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-topic.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-topic.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Topic to send the message to using the specified provider. You can specify variables such as $MY_TOPIC
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/RabbitMQSubscriberProviderDataDescriptor/rabbitmq-subscriber.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/RabbitMQSubscriberProviderDataDescriptor/rabbitmq-subscriber.jelly
@@ -1,0 +1,81 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     *
+  -->
+
+  <f:nested>
+    <j:choose>
+      <j:when test="${empty(instance)}">
+        <j:set var="checked" value="${pdata.hasOverrides();}"/>
+        <j:set var="value" value="${pdata.getSubscriberTopic();}"/>
+        <j:set var="name" value="${pdata.getName();}"/>
+      </j:when>
+      <j:otherwise>
+        <j:set var="checked" value="${instance.getOverrides() != null}"/>
+        <j:set var="value" value="${instance.getOverrides().getTopic();}"/>
+        <j:set var="name" value="${instance.getName();}"/>
+      </j:otherwise>
+    </j:choose>
+    <table width="100%">
+      <f:optionalBlock field="overrides" title="Override provider topic" checked="${checked}">
+        <f:entry title="${%Topic name}" field="topic">
+          <f:textbox value="${value}"/>
+        </f:entry>
+      </f:optionalBlock>
+      <f:optionalBlock field="overrides" title="Override provider queue" checked="${checked}">
+        <f:entry title="${%Queue name}" field="queue">
+          <f:textbox value="${value}"/>
+        </f:entry>
+      </f:optionalBlock>
+    </table>
+    <f:entry title="${%Message Checks}" help="/plugin/jms-messaging/help-checks.html">
+        <f:repeatable var="check" name="checks" items="${instance.checks}" add="${%Add check}" minimum="0">
+          <table width="100%">
+            <f:entry title="${%Field}">
+              <f:textbox name="checks.field" value="${check.field}"
+                         checkUrl="'descriptorByName/com.redhat.jenkins.plugins.ci.CIBuildTrigger/checkField?value='+escape(this.value)" />
+            </f:entry>
+            <f:entry title="${%Expected value}">
+              <f:textbox name="checks.expectedValue" value="${check.expectedValue}" />
+            </f:entry>
+            <f:entry>
+              <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                <f:repeatableDeleteButton value="${%Delete check}" />
+                <br/>
+              </div>
+            </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+    <j:if test="${desc.getClass().getSimpleName() != 'CIBuildTriggerDescriptor'}">
+      <f:entry title="${%Variable}" field="variable">
+        <f:textbox default="${descriptor.getDefaultVariable()}"/>
+      </f:entry>
+      <f:entry title="${%Timeout}" field="timeout">
+        <f:textbox default="${descriptor.getDefaultTimeout()}"/>
+      </f:entry>
+    </j:if>
+  </f:nested>
+</j:jelly>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-timeout.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-timeout.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Value (in minutes) to wait for a message.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-topic.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-topic.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Topic to subscribe to using the specified provider.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-variable.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-variable.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Environment variable to hold received message content.</p>
+</div>


### PR DESCRIPTION
This client is based on [RabbitMQ Java
Client](https://www.rabbitmq.com/java-client.html).

Supports SSL and Username/Password authentication and could be
configured to work with any RabbitMQ server.

Connection to each server is created only once and separate channel is
created for each consumer and publisher.

When publishing generates message id using java.util.UUID and send this
id as property of the message.

Consuming is done using by using Push API (subscription) even when
listening for messages for a limited time.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>