### PR TITLE
 Add simple client for RabbitMQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <version>5.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.9.10</version>

--- a/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
@@ -1,5 +1,7 @@
 package com.redhat.jenkins.plugins.ci;
 
+import com.redhat.jenkins.plugins.ci.messaging.FedMsgMessagingProvider;
+import com.redhat.jenkins.plugins.ci.provider.data.*;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.PluginManager;
@@ -30,11 +32,6 @@ import com.redhat.jenkins.plugins.ci.messaging.ActiveMqMessagingProvider;
 import com.redhat.jenkins.plugins.ci.messaging.JMSMessagingProvider;
 import com.redhat.jenkins.plugins.ci.messaging.topics.DefaultTopicProvider;
 import com.redhat.jenkins.plugins.ci.messaging.topics.TopicProvider.TopicProviderDescriptor;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQSubscriberProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
 
 /*
  * The MIT License
@@ -248,8 +245,10 @@ public final class GlobalCIConfiguration extends GlobalConfiguration {
             for (JMSMessagingProvider p : getConfigs()) {
                 if (p instanceof ActiveMqMessagingProvider) {
                     pds.add(new ActiveMQSubscriberProviderData(p.getName()));
-                } else {
+                } else if (p instanceof FedMsgMessagingProvider) {
                     pds.add(new FedMsgSubscriberProviderData(p.getName()));
+                } else {
+                    pds.add(new RabbitMQSubscriberProviderData(p.getName()));
                 }
             }
         }
@@ -262,8 +261,10 @@ public final class GlobalCIConfiguration extends GlobalConfiguration {
             for (JMSMessagingProvider p : getConfigs()) {
                 if (p instanceof ActiveMqMessagingProvider) {
                     pds.add(new ActiveMQPublisherProviderData(p.getName()));
-                } else {
+                } else if (p instanceof FedMsgMessagingProvider) {
                     pds.add(new FedMsgPublisherProviderData(p.getName()));
+                } else {
+                    pds.add(new RabbitMQPublisherProviderData(p.getName()));
                 }
             }
         }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/RabbitMQAuthenticationMethod.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/RabbitMQAuthenticationMethod.java
@@ -1,15 +1,10 @@
-package com.redhat.jenkins.plugins.ci.authentication.activemq;
+package com.redhat.jenkins.plugins.ci.authentication.rabbitmq;
 
-import hudson.ExtensionList;
+import com.rabbitmq.client.ConnectionFactory;
+
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-
-import org.apache.activemq.ActiveMQConnectionFactory;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import hudson.ExtensionList;
 
 import jenkins.model.Jenkins;
 
@@ -38,27 +33,16 @@ import com.redhat.jenkins.plugins.ci.authentication.AuthenticationMethod;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-public abstract class ActiveMQAuthenticationMethod extends AuthenticationMethod implements Describable<ActiveMQAuthenticationMethod> {
+public abstract class RabbitMQAuthenticationMethod extends AuthenticationMethod implements Describable<RabbitMQAuthenticationMethod> {
 
     private static final long serialVersionUID = -6077120270692721571L;
-    private transient static final Logger log = Logger.getLogger(AuthenticationMethod.class.getName());
 
-    public abstract static class AuthenticationMethodDescriptor extends Descriptor<ActiveMQAuthenticationMethod> {
+    public abstract static class AuthenticationMethodDescriptor extends Descriptor<RabbitMQAuthenticationMethod> {
         public static ExtensionList<AuthenticationMethodDescriptor> all() {
             return Jenkins.getInstance().getExtensionList(AuthenticationMethodDescriptor.class);
         }
-
-        public static boolean isValidURL(String url) {
-            try {
-                new URI(url);
-            } catch (URISyntaxException e) {
-                log.log(Level.SEVERE, "URISyntaxException, returning false.");
-                return false;
-            }
-            return true;
-        }
     }
 
-
-    public abstract ActiveMQConnectionFactory getConnectionFactory(String broker);
+    public abstract ConnectionFactory getConnectionFactory(String hostname, Integer portNumber,
+                                                           String VirtualHost);
 }

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.redhat.jenkins.plugins.ci.authentication.AuthenticationMethod.AuthenticationMethodDescriptor;
+import com.redhat.jenkins.plugins.ci.authentication.activemq.ActiveMQAuthenticationMethod.AuthenticationMethodDescriptor;
 import com.redhat.jenkins.plugins.ci.authentication.activemq.ActiveMQAuthenticationMethod;
 import com.redhat.jenkins.plugins.ci.authentication.activemq.UsernameAuthenticationMethod;
 import com.redhat.jenkins.plugins.ci.messaging.topics.DefaultTopicProvider;

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -87,10 +87,9 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
     private MessageConsumer subscriber;
     private String uuid = UUID.randomUUID().toString();
 
-    public ActiveMqMessagingWorker(ActiveMqMessagingProvider provider, MessagingProviderOverrides overrides, String jobname) {
-        this.provider = provider;
-        this.overrides = overrides;
-        this.jobname = jobname;
+    public ActiveMqMessagingWorker(JMSMessagingProvider messagingProvider, MessagingProviderOverrides overrides, String jobname) {
+        super(messagingProvider, overrides, jobname);
+        this.provider = (ActiveMqMessagingProvider) messagingProvider;
     }
 
     @Override

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/FedMsgMessagingWorker.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/FedMsgMessagingWorker.java
@@ -55,9 +55,8 @@ public class FedMsgMessagingWorker extends JMSMessagingWorker {
 
     private static final Logger log = Logger.getLogger(FedMsgMessagingWorker.class.getName());
 
-    private final FedMsgMessagingProvider provider;
-
     public static final String DEFAULT_TOPIC = "org.fedoraproject";
+    private final FedMsgMessagingProvider provider;
 
     private ZMQ.Context context;
     private ZMQ.Poller poller;
@@ -66,10 +65,9 @@ public class FedMsgMessagingWorker extends JMSMessagingWorker {
 
     private boolean pollerClosed = false;
 
-    public FedMsgMessagingWorker(FedMsgMessagingProvider fedMsgMessagingProvider, MessagingProviderOverrides overrides, String jobname) {
-        this.provider = fedMsgMessagingProvider;
-        this.overrides = overrides;
-        this.jobname = jobname;
+    public FedMsgMessagingWorker(JMSMessagingProvider messagingProvider, MessagingProviderOverrides overrides, String jobname) {
+        super(messagingProvider, overrides, jobname);
+        this.provider = (FedMsgMessagingProvider) messagingProvider;
     }
 
     @Override

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/JMSMessagingWorker.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/JMSMessagingWorker.java
@@ -55,6 +55,11 @@ public abstract class JMSMessagingWorker {
 
     public abstract void disconnect();
 
+    public JMSMessagingWorker(JMSMessagingProvider messagingProvider, MessagingProviderOverrides overrides, String jobname) {
+        this.overrides = overrides;
+        this.jobname = jobname;
+    }
+
     public abstract SendResult sendMessage(Run<?, ?> build, TaskListener listener, ProviderData pdata);
     public abstract String waitForMessage(Run<?, ?> build, TaskListener listener, ProviderData pdata);
 

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessageProviderMigrator.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessageProviderMigrator.java
@@ -1,5 +1,6 @@
 package com.redhat.jenkins.plugins.ci.messaging;
 
+import com.redhat.jenkins.plugins.ci.provider.data.*;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -18,10 +19,6 @@ import com.redhat.jenkins.plugins.ci.CIMessageBuilder;
 import com.redhat.jenkins.plugins.ci.CIMessageNotifier;
 import com.redhat.jenkins.plugins.ci.CIMessageSubscriberBuilder;
 import com.redhat.jenkins.plugins.ci.GlobalCIConfiguration;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQSubscriberProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgPublisherProviderData;
-import com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData;
 
 /*
  * The MIT License
@@ -71,12 +68,18 @@ public class MessageProviderMigrator {
                 apd.setMessageContent(builder.getMessageContent());
                 apd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(apd);
-            } else {
+            } else if (prov instanceof FedMsgMessagingProvider) {
                 FedMsgPublisherProviderData fpd = new FedMsgPublisherProviderData(builder.getProviderName());
                 fpd.setOverrides(builder.getOverrides());
                 fpd.setMessageContent(builder.getMessageContent());
                 fpd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(fpd);
+            } else {
+                RabbitMQPublisherProviderData rpd = new RabbitMQPublisherProviderData(builder.getProviderName());
+                rpd.setOverrides(builder.getOverrides());
+                rpd.setMessageContent(builder.getMessageContent());
+                rpd.setFailOnError(builder.isFailOnError());
+                builder.setProviderData(rpd);
             }
             try {
                 p.save();
@@ -108,12 +111,18 @@ public class MessageProviderMigrator {
                 apd.setMessageContent(builder.getMessageContent());
                 apd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(apd);
-            } else {
+            } else if (prov instanceof FedMsgMessagingProvider) {
                 FedMsgPublisherProviderData fpd = new FedMsgPublisherProviderData(builder.getProviderName());
                 fpd.setOverrides(builder.getOverrides());
                 fpd.setMessageContent(builder.getMessageContent());
                 fpd.setFailOnError(builder.isFailOnError());
                 builder.setProviderData(fpd);
+            } else {
+                RabbitMQPublisherProviderData rpd = new RabbitMQPublisherProviderData(builder.getProviderName());
+                rpd.setOverrides(builder.getOverrides());
+                rpd.setMessageContent(builder.getMessageContent());
+                rpd.setFailOnError(builder.isFailOnError());
+                builder.setProviderData(rpd);
             }
             try {
                 p.save();
@@ -144,12 +153,18 @@ public class MessageProviderMigrator {
                 apd.setVariable(builder.getVariable());
                 apd.setTimeout(builder.getTimeout());
                 builder.setProviderData(apd);
-            } else {
+            } else if (prov instanceof FedMsgMessagingProvider) {
                 FedMsgSubscriberProviderData fpd = new FedMsgSubscriberProviderData(builder.getProviderName());
                 fpd.setOverrides(builder.getOverrides());
                 fpd.setVariable(builder.getVariable());
                 fpd.setTimeout(builder.getTimeout());
                 builder.setProviderData(fpd);
+            } else {
+                RabbitMQSubscriberProviderData rpd = new RabbitMQSubscriberProviderData(builder.getProviderName());
+                rpd.setOverrides(builder.getOverrides());
+                rpd.setVariable(builder.getVariable());
+                rpd.setTimeout(builder.getTimeout());
+                builder.setProviderData(rpd);
             }
             try {
                 p.save();

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessagingProviderOverrides.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/MessagingProviderOverrides.java
@@ -16,6 +16,7 @@ public class MessagingProviderOverrides implements Describable<MessagingProvider
     private static final long serialVersionUID = -8815444484948038651L;
 
     private String topic;
+    private String queue;
 
     @Whitelisted
     @DataBoundConstructor
@@ -27,9 +28,19 @@ public class MessagingProviderOverrides implements Describable<MessagingProvider
         return topic;
     }
 
+
+    public String getQueue() {
+        return queue;
+    }
+
     @DataBoundSetter
     public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+    @DataBoundSetter
+    public void setQueue(String queue) {
+        this.queue = queue;
     }
 
     @Override
@@ -39,7 +50,8 @@ public class MessagingProviderOverrides implements Describable<MessagingProvider
 
         MessagingProviderOverrides that = (MessagingProviderOverrides) o;
 
-        return topic != null ? topic.equals(that.topic) : that.topic == null;
+        return (topic != null ? topic.equals(that.topic) : that.topic == null) &&
+                (queue != null ? queue.equals(that.queue) : that.queue == null);
     }
 
     @Override

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessageWatcher.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessageWatcher.java
@@ -1,0 +1,22 @@
+package com.redhat.jenkins.plugins.ci.messaging;
+
+import java.util.logging.Logger;
+
+public class RabbitMQMessageWatcher extends JMSMessageWatcher {
+
+    private static final Logger log = Logger.getLogger(RabbitMQMessageWatcher.class.getName());
+
+    public RabbitMQMessageWatcher(String jobname) {
+        super(jobname);
+    }
+
+    @Override
+    public String watch() {
+        return null;
+    }
+
+    @Override
+    public void interrupt() {
+
+    }
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider.java
@@ -1,0 +1,96 @@
+package com.redhat.jenkins.plugins.ci.messaging;
+
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.logging.Logger;
+
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Connection;
+
+import com.redhat.jenkins.plugins.ci.authentication.rabbitmq.RabbitMQAuthenticationMethod.AuthenticationMethodDescriptor;
+import com.redhat.jenkins.plugins.ci.authentication.rabbitmq.RabbitMQAuthenticationMethod;
+import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQProviderData;
+
+public class RabbitMQMessagingProvider extends JMSMessagingProvider {
+
+    private static final long serialVersionUID = 82154526798596907L;
+
+    private static final Logger log = Logger.getLogger(RabbitMQMessagingProvider.class.getName());
+
+    private String virtualHost;
+    private String hostname;
+    private Integer portNumber;
+    private RabbitMQAuthenticationMethod authenticationMethod;
+    private Connection connection;
+    private String exchange;
+    private String queue;
+
+    @DataBoundConstructor
+    public RabbitMQMessagingProvider(String name, String virtualHost,
+                                     String hostname, Integer portNumber,
+                                     String topic, String exchange, String queue,
+                                     RabbitMQAuthenticationMethod authenticationMethod) {
+        this.name = name;
+        this.virtualHost = virtualHost;
+        this.hostname = hostname;
+        this.portNumber = portNumber;
+        this.topic = topic;
+        this.exchange = exchange;
+        this.queue = queue;
+        this.authenticationMethod = authenticationMethod;
+    }
+
+    public String getVirtualHost() { return virtualHost; }
+
+    public String getHostname() { return hostname; }
+
+    public Integer getPortNumber() { return portNumber; }
+
+    public String getTopic() { return topic; }
+
+    public String getExchange() { return exchange; }
+
+    public String getQueue() { return queue; }
+
+    public Connection getConnection() { return connection; }
+
+    public void setConnection(Connection connection) { this.connection = connection; }
+
+    public RabbitMQAuthenticationMethod getAuthenticationMethod() { return authenticationMethod; }
+
+    public ConnectionFactory getConnectionFactory() {
+        return authenticationMethod.getConnectionFactory(getHostname(), getPortNumber(), getVirtualHost());
+    }
+
+    @Override
+    public JMSMessagingWorker createWorker(ProviderData pdata, String jobname) {
+        return new RabbitMQMessagingWorker(this, ((RabbitMQProviderData)pdata).getOverrides(), jobname);
+    }
+
+    @Override
+    public JMSMessageWatcher createWatcher(String jobname) {
+        return new RabbitMQMessageWatcher(jobname);
+    }
+
+    @Override
+    public Descriptor<JMSMessagingProvider> getDescriptor() {
+        return Jenkins.getInstance().getDescriptorByType(RabbitMQMessagingProvider.RabbitMQProviderDescriptor.class);
+    }
+
+    @Extension
+    public static class RabbitMQProviderDescriptor extends MessagingProviderDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "RabbitMQ";
+        }
+
+        public ExtensionList<AuthenticationMethodDescriptor> getAuthenticationMethodDescriptors() {
+            return AuthenticationMethodDescriptor.all();
+        }
+    }
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
@@ -1,0 +1,455 @@
+package com.redhat.jenkins.plugins.ci.messaging;
+
+import com.rabbitmq.client.*;
+import com.redhat.jenkins.plugins.ci.CIEnvironmentContributingAction;
+import com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck;
+import com.redhat.jenkins.plugins.ci.messaging.data.RabbitMQMessage;
+import com.redhat.jenkins.plugins.ci.messaging.data.SendResult;
+import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQPublisherProviderData;
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQSubscriberProviderData;
+import com.redhat.utils.PluginUtils;
+import hudson.EnvVars;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RabbitMQMessagingWorker extends JMSMessagingWorker {
+
+    private static final Logger log = Logger.getLogger(RabbitMQMessagingWorker.class.getName());
+    private final RabbitMQMessagingProvider provider;
+
+    private Connection connection;
+    private Channel channel;
+    // Thread interruption flag
+    private boolean interrupt = false;
+    private String uuid = UUID.randomUUID().toString();
+    // Concurrent message queue used for saving messages from consumer
+    private ConcurrentLinkedQueue<RabbitMQMessage> messageQueue = new ConcurrentLinkedQueue<RabbitMQMessage>();
+    private String consumerTag = "";
+    private String queueName = "";
+    private String exchangeName = "";
+
+    public RabbitMQMessagingWorker(JMSMessagingProvider messagingProvider, MessagingProviderOverrides overrides, String jobname) {
+        super(messagingProvider, overrides, jobname);
+        this.provider = (RabbitMQMessagingProvider) messagingProvider;
+        this.connection = provider.getConnection();
+        this.exchangeName = provider.getExchange();
+        this.queueName = provider.getQueue();
+        this.topic = getTopic(provider);
+    }
+
+    @Override
+    public boolean subscribe(String jobname, String selector) {
+        if (interrupt) {
+            return true;
+        }
+        if (this.topic != null) {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    if (connection == null || !connection.isOpen()) {
+                        if (!connect()) {
+                            return false;
+                        }
+                    }
+                    if (channel == null || !channel.isOpen()) {
+                        this.channel = connection.createChannel();
+                        log.info("Subscribing job '" + jobname + "' to " + this.topic + " topic.");
+                        channel.exchangeDeclarePassive(exchangeName);
+                        String queueName = getQueue(provider);
+                        channel.queueBind(queueName, exchangeName, this.topic);
+
+                        // Create deliver callback to listen for messages
+                        DeliverCallback deliverCallback = (consumerTag, delivery) -> {
+                            String json = new String(delivery.getBody(), "UTF-8");
+                            log.info(
+                                    "Received '" + delivery.getEnvelope().getRoutingKey() + "':\n" + "Message id: '" + delivery.getProperties().getMessageId() + "'\n'" + json + "'");
+                            RabbitMQMessage message = new RabbitMQMessage(delivery.getEnvelope().getRoutingKey(), json, delivery.getProperties().getMessageId());
+                            message.setTimestamp(new Date().getTime());
+                            message.setDeliveryTag(delivery.getEnvelope().getDeliveryTag());
+                            messageQueue.add(message);
+
+                        };
+                        this.consumerTag = channel.basicConsume(queueName, deliverCallback, (CancelCallback) null);
+                        log.info("Successfully subscribed job '" + jobname + "' to topic '" + this.topic + "'.");
+                    } else {
+                        log.info("Already subscribed job '" + jobname + "' to topic '" + this.topic + "'.");
+                    }
+                    return true;
+                } catch (Exception ex) {
+
+                    // Either we were interrupted, or something else went
+                    // wrong. If we were interrupted, then we will jump ship
+                    // on the next iteration. If something else happened,
+                    // then we just unsubscribe here, sleep, so that we may
+                    // try again on the next iteration.
+
+                    log.log(Level.SEVERE, "Eexception raised while subscribing job '" + jobname + "', retrying in " + RETRY_MINUTES + " minutes.", ex);
+                    if (!Thread.currentThread().isInterrupted()) {
+
+                        unsubscribe(jobname);
+
+                        try {
+                            Thread.sleep(RETRY_MINUTES * 60 * 1000);
+                        } catch (InterruptedException ie) {
+                            // We were interrupted while waiting to retry.
+                            // We will jump ship on the next iteration.
+
+                            // NB: The interrupt flag was cleared when
+                            // InterruptedException was thrown. We have to
+                            // re-install it to make sure we eventually
+                            // leave this thread.
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void unsubscribe(String jobname) {
+        if (interrupt) {
+            log.info("We are being interrupted. Skipping unsubscribe...");
+            return;
+        }
+        try {
+            channel.basicCancel(consumerTag);
+            channel.close();
+        } catch (Exception ex) {
+            log.warning("Exception occurred when closing channel: " + ex.getMessage());
+        }
+
+    }
+
+    @Override
+    public void receive(String jobname, ProviderData pdata) {
+        RabbitMQSubscriberProviderData pd = (RabbitMQSubscriberProviderData) pdata;
+        Integer timeout = (pd.getTimeout() != null ? pd.getTimeout() : RabbitMQSubscriberProviderData.DEFAULT_TIMEOUT_IN_MINUTES) * 60 * 1000;
+
+        if (interrupt) {
+            log.info("we have been interrupted at start of receive");
+            return;
+        }
+
+        // subscribe job
+        while (!subscribe(jobname)) {
+            if (!Thread.currentThread().isInterrupted()) {
+                try {
+                    int WAIT_SECONDS = 2;
+                    Thread.sleep(WAIT_SECONDS * 1000);
+                } catch (InterruptedException e) {
+                    // We were interrupted while waiting to retry. We will
+                    // jump ship on the next iteration.
+
+                    // NB: The interrupt flag was cleared when
+                    // InterruptedException was thrown. We have to
+                    // re-install it to make sure we eventually leave this
+                    // thread.
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        long lastSeenMessage = new Date().getTime();
+
+        try {
+            while ((new Date().getTime() - lastSeenMessage) < timeout) {
+                if (!messageQueue.isEmpty()) {
+                    RabbitMQMessage data = messageQueue.poll();
+                    // Reset timer
+                    lastSeenMessage = data.getTimestamp().getTime();
+                    //
+                    if (provider.verify(data.getBodyJson(), pd.getChecks(), jobname)) {
+                        Map<String, String> params = new HashMap<String, String>();
+                        params.put("CI_MESSAGE", data.toJson());
+                        trigger(jobname, data.getBodyJson(), params);
+                    }
+                    channel.basicAck(data.getDeliveryTag(), false);
+                } else {
+                    if (interrupt) {
+                        log.info("We have been interrupted...");
+                        break;
+                    }
+                }
+                TimeUnit.MILLISECONDS.sleep(500);
+            }
+        } catch (Exception e) {
+            // If InterruptedException is caught, interrupt is cleared
+            // and it needs to be set again
+            // See https://stackoverflow.com/questions/7142665/why-does-thread-isinterrupted-always-return-false
+            // for more info
+            if (e.getClass() == InterruptedException.class) {
+                Thread.currentThread().interrupt();
+            }
+            if (!Thread.currentThread().isInterrupted()) {
+                // Something other than an interrupt causes this.
+                // Unsubscribe, but stay in our loop and try to reconnect..
+                log.log(Level.WARNING, "JMS exception raised, going to re-subscribe for job '" + jobname + "'.", e);
+                unsubscribe(jobname); // Try again next time.
+            }
+        }
+    }
+
+    @Override
+    public boolean connect() {
+        ConnectionFactory connectionFactory = provider.getConnectionFactory();
+        Connection connectiontmp = null;
+        try {
+            connectiontmp = connectionFactory.newConnection();
+            String url = "";
+            if (Jenkins.getInstanceOrNull() != null) {
+                url = Jenkins.get().getRootUrl();
+            }
+            connectiontmp.setId(provider.getName() + "_" + url + "_" + uuid + "_" + jobname);
+        } catch (Exception e) {
+            log.severe("Unable to connect to " + provider.getHostname() + ":" + provider.getPortNumber() + " " + e.getMessage());
+            return false;
+        }
+        log.info("Connection created");
+        connection = connectiontmp;
+        provider.setConnection(connection);
+        return true;
+    }
+
+    @Override
+    public void disconnect() {
+        try {
+            channel.close();
+        } catch (Exception ex) {
+            log.warning("Exception occurred when closing channel: " + ex.getMessage());
+        }
+        try {
+            connection.close();
+        } catch (Exception ex) {
+            log.warning("Exception occurred when closing connection: " + ex.getMessage());
+        }
+    }
+
+    @Override
+    public SendResult sendMessage(Run<?, ?> build, TaskListener listener, ProviderData pdata) {
+        RabbitMQPublisherProviderData pd = (RabbitMQPublisherProviderData)pdata;
+        try {
+            if (connection == null || !connection.isOpen()) {
+                connect();
+            }
+            if (channel == null || !channel.isOpen()) {
+                this.channel = connection.createChannel();
+                log.info("Channel created.");
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        String body = "";
+        String msgId = "";
+        try {
+
+            EnvVars env = new EnvVars();
+            env.putAll(build.getEnvironment(listener));
+            env.put("CI_NAME", build.getParent().getName());
+            if (!build.isBuilding()) {
+                env.put("CI_STATUS", (build.getResult() == Result.SUCCESS ? "passed" : "failed"));
+                env.put("BUILD_STATUS", build.getResult().toString());
+            }
+
+            RabbitMQMessage msg = new RabbitMQMessage(PluginUtils.getSubstitutedValue(getTopic(provider), build.getEnvironment(listener)),
+                                                     PluginUtils.getSubstitutedValue(pd.getMessageContent(), env));
+
+            msg.setTimestamp(System.currentTimeMillis());
+
+            body = msg.getBodyJson();
+            msgId = msg.getMsgId();
+            try {
+                channel.exchangeDeclarePassive(exchangeName);
+                channel.basicPublish(exchangeName, msg.getTopic(),
+                        new AMQP.BasicProperties.Builder()
+                        .messageId(msgId).build(), body.getBytes());
+            } catch (IOException e) {
+                if (pd.isFailOnError()) {
+                    log.severe("Unhandled exception in perform: Failed to send message!");
+                    return new SendResult(false, msgId, body);
+                }
+            }
+            log.fine("JSON message:\n" + msg.toJson());
+            listener.getLogger().println("Message id: " + msg.getMsgId());
+            listener.getLogger().println("Message topic: " + msg.getTopic());
+            listener.getLogger().println("JSON message body:\n" + body);
+
+        } catch (Exception e) {
+            if (pd.isFailOnError()) {
+                log.severe("Unhandled exception in perform: ");
+                log.severe(ExceptionUtils.getStackTrace(e));
+                listener.fatalError("Unhandled exception in perform: ");
+                listener.fatalError(ExceptionUtils.getStackTrace(e));
+                return new SendResult(false, msgId, body);
+            } else {
+                log.warning("Unhandled exception in perform: ");
+                log.warning(ExceptionUtils.getStackTrace(e));
+                listener.error("Unhandled exception in perform: ");
+                listener.error(ExceptionUtils.getStackTrace(e));
+                return new SendResult(true, msgId, body);
+            }
+        } finally {
+            try {
+                channel.close();
+            } catch (Exception e) {
+                log.warning("Unhandled exception when closing channel: ");
+                log.warning(ExceptionUtils.getStackTrace(e));
+                listener.getLogger().println("exception in finally");
+            }
+        }
+        return new SendResult(true, msgId, body);
+    }
+
+    @Override
+    public String waitForMessage(Run<?, ?> build, TaskListener listener, ProviderData pdata) {
+        RabbitMQSubscriberProviderData pd = (RabbitMQSubscriberProviderData)pdata;
+
+        try {
+            if (connection == null || !connection.isOpen()) {
+                connect();
+            }
+            if (channel == null || !channel.isOpen()) {
+                this.channel = connection.createChannel();
+            }
+            channel.exchangeDeclarePassive(exchangeName);
+            channel.queueBind(getQueue(provider), exchangeName, this.topic);
+        } catch (Exception ex) {
+            log.severe("Connection to broker can't be established!");
+            log.severe(ExceptionUtils.getStackTrace(ex));
+            listener.error("Connection to broker can't be established!");
+            listener.error(ExceptionUtils.getStackTrace(ex));
+            return null;
+        }
+
+        log.info("Waiting for message.");
+        listener.getLogger().println("Waiting for message.");
+        for (MsgCheck msgCheck: pd.getChecks()) {
+            log.info(" with check: " + msgCheck.toString());
+            listener.getLogger().println(" with check: " + msgCheck.toString());
+        }
+        Integer timeout = (pd.getTimeout() != null ? pd.getTimeout() : RabbitMQSubscriberProviderData.DEFAULT_TIMEOUT_IN_MINUTES);
+        log.info(" with timeout: " + timeout + " minutes");
+        listener.getLogger().println(" with timeout: " + timeout + " minutes");
+
+
+        // Create deliver callback to listen for messages
+        DeliverCallback deliverCallback = (consumerTag, delivery) -> {
+            String json = new String(delivery.getBody(), "UTF-8");
+            listener.getLogger().println(
+                    "Received '" + delivery.getEnvelope().getRoutingKey() + "':\n" + "Message id: '" + delivery.getProperties().getMessageId() + "'\n'" + json + "'");
+            log.info(
+                    "Received '" + delivery.getEnvelope().getRoutingKey() + "':\n" + "Message id: '" + delivery.getProperties().getMessageId() + "'\n'" + json + "'");
+            RabbitMQMessage message = new RabbitMQMessage(delivery.getEnvelope().getRoutingKey(), json, delivery.getProperties().getMessageId());
+            message.setTimestamp(new Date().getTime());
+            message.setDeliveryTag(delivery.getEnvelope().getDeliveryTag());
+            messageQueue.add(message);
+
+        };
+
+        String consumerTag = null;
+
+        long startTime = new Date().getTime();
+
+        int timeoutInMs = timeout * 60 * 1000;
+
+        try {
+            consumerTag = channel.basicConsume(getQueue(provider), deliverCallback, (CancelCallback) null);
+            while ((new Date().getTime() - startTime) < timeoutInMs) {
+                if (!messageQueue.isEmpty()) {
+
+                    RabbitMQMessage message = messageQueue.poll();
+                    log.info("Obtained message from queue: " + message.toJson());
+
+                    if (!provider.verify(message.getBodyJson(), pd.getChecks(), jobname)) {
+                        channel.basicAck(message.getDeliveryTag(), false);
+                        continue;
+                    }
+                    listener.getLogger().println(
+                            "Message: '" + message.getMsgId() + "' was succesfully checked.");
+
+                    if (build != null) {
+                        if (StringUtils.isNotEmpty(pd.getVariable())) {
+                            EnvVars vars = new EnvVars();
+                            vars.put(pd.getVariable(), message.getBodyJson());
+                            build.addAction(new CIEnvironmentContributingAction(vars));
+                        }
+                    }
+                    channel.basicAck(message.getDeliveryTag(), false);
+                    return message.getBodyJson();
+                }
+                if (interrupt) {
+                    return null;
+                }
+                TimeUnit.MILLISECONDS.sleep(500);
+            }
+            log.severe("Timed out waiting for message!");
+            listener.getLogger().println("Timed out waiting for message!");
+        } catch (Exception e) {
+            // If InterruptedException is caught, interrupt is cleared
+            // and it needs to be set again
+            // See https://stackoverflow.com/questions/7142665/why-does-thread-isinterrupted-always-return-false
+            // for more info
+            if (e.getClass() == InterruptedException.class) {
+                Thread.currentThread().interrupt();
+            }
+
+            log.log(Level.SEVERE, "Unhandled exception waiting for message.", e);
+        } finally {
+            try {
+                if (consumerTag != null) {
+                    channel.basicCancel(consumerTag);
+                }
+                channel.close();
+            } catch (Exception e) {
+                listener.getLogger().println("exception in finally");
+            }
+        }
+        return null;
+    }
+
+    public void prepareForInterrupt() {
+        interrupt = true;
+    }
+
+    public boolean isBeingInterrupted() {
+        return interrupt;
+    }
+
+    @Override
+    public String getDefaultTopic() {
+        return null;
+    }
+
+    protected String getQueue(JMSMessagingProvider provider) throws IOException {
+        String ltopic;
+        RabbitMQMessagingProvider providerd = (RabbitMQMessagingProvider) provider;
+        if (overrides != null && overrides.getQueue() != null && !overrides.getQueue().isEmpty()) {
+            ltopic = overrides.getQueue();
+        } else if (providerd.getQueue() != null && !providerd.getQueue().isEmpty()) {
+            ltopic = providerd.getQueue();
+        } else {
+            // The queue is not set anywhere, let's use random queue
+            if (queueName.isEmpty()) {
+                queueName = channel.queueDeclare().getQueue();
+            }
+            ltopic = queueName;
+        }
+        return PluginUtils.getSubstitutedValue(ltopic, null);
+    }
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/data/RabbitMQMessage.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/data/RabbitMQMessage.java
@@ -1,0 +1,167 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.redhat.jenkins.plugins.ci.messaging.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder(
+        alphabetic = true
+)
+public class RabbitMQMessage {
+
+    private static final Logger log = Logger.getLogger(RabbitMQMessage.class.getName());
+
+    private long timestamp;
+    private String topic;
+    private String msgId;
+    private long deliveryTag;
+    @JsonProperty("msg")
+    private Map<String, Object> msg = null;
+
+    public RabbitMQMessage() {}
+
+    public RabbitMQMessage(String topic) {
+        this(topic, null, null);
+    }
+
+    public RabbitMQMessage(String topic, String body) {
+        this(topic, body, null);
+    }
+
+    public RabbitMQMessage(String topic, String body, String msgId) {
+        this.topic = topic;
+        if (msgId != null) {
+            this.msgId = msgId;
+        }
+        else {
+            this.msgId = Integer.toString(Calendar.getInstance().get(1)) + "-" + UUID.randomUUID().toString();
+        }
+
+        if (!StringUtils.isBlank(body)) {
+            try {
+                log.fine("Message to deserialize: '" + body + "'");
+                ObjectMapper mapper = new ObjectMapper();
+                TypeReference<HashMap<String,Object>> typeRef = new TypeReference<HashMap<String,Object>>() {};
+                msg = mapper.readValue(body, typeRef);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Unable to deserialize message body.", e);
+            }
+        }
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public Date getTimestamp() {
+        return new Date(this.timestamp);
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public long getDeliveryTag() { return deliveryTag; }
+
+    public void setDeliveryTag(long deliveryTag) { this.deliveryTag = deliveryTag; }
+
+    @JsonProperty("msg_id")
+    public final String getMsgId() {
+        return this.msgId;
+    }
+
+    public Map<String, Object> getMsg() {
+        return msg;
+    }
+
+    public void setMsg(Map<String, Object> msg) {
+        this.msg = msg;
+    }
+
+    @JsonIgnore
+    public String getBodyJson() {
+        if (msg != null) {
+            return JSONObject.fromObject(msg).toString();
+        }
+        return "";
+    }
+
+    public String toJson() {
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectWriter writer = mapper.writer();
+            writer.with(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS).writeValue(os, this);
+            os.close();
+            return new String(os.toByteArray(), "UTF-8");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/pipeline/CIMessageSenderStep.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/pipeline/CIMessageSenderStep.java
@@ -1,5 +1,6 @@
 package com.redhat.jenkins.plugins.ci.pipeline;
 
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQPublisherProviderData;
 import com.redhat.utils.MessageUtils;
 import hudson.Extension;
 import hudson.Launcher;
@@ -184,6 +185,12 @@ public class CIMessageSenderStep extends Step {
                             fpd.setMessageContent(step.getMessageContent());
                             fpd.setFailOnError(step.getFailOnError());
                             pd = fpd;
+                        } else {
+                            RabbitMQPublisherProviderData rpd = new RabbitMQPublisherProviderData(step.getProviderName());
+                            rpd.setOverrides(step.getOverrides());
+                            rpd.setMessageContent(step.getMessageContent());
+                            rpd.setFailOnError(step.getFailOnError());
+                            pd = rpd;
                         }
                         CIMessageNotifier notifier = new CIMessageNotifier(pd);
                         StepContext c = getContext();

--- a/src/main/java/com/redhat/jenkins/plugins/ci/pipeline/CIMessageSubscriberStep.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/pipeline/CIMessageSubscriberStep.java
@@ -1,5 +1,7 @@
 package com.redhat.jenkins.plugins.ci.pipeline;
 
+import com.redhat.jenkins.plugins.ci.messaging.*;
+import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQSubscriberProviderData;
 import com.redhat.utils.MessageUtils;
 import hudson.AbortException;
 import hudson.Extension;
@@ -29,10 +31,6 @@ import com.google.common.collect.ImmutableSet;
 import com.redhat.jenkins.plugins.ci.CIMessageSubscriberBuilder;
 import com.redhat.jenkins.plugins.ci.GlobalCIConfiguration;
 import com.redhat.jenkins.plugins.ci.Messages;
-import com.redhat.jenkins.plugins.ci.messaging.ActiveMqMessagingProvider;
-import com.redhat.jenkins.plugins.ci.messaging.FedMsgMessagingProvider;
-import com.redhat.jenkins.plugins.ci.messaging.JMSMessagingProvider;
-import com.redhat.jenkins.plugins.ci.messaging.MessagingProviderOverrides;
 import com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck;
 import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQSubscriberProviderData;
 import com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData;
@@ -168,8 +166,14 @@ public class CIMessageSubscriberStep extends Step {
                             fpd.setChecks(step.getChecks());
                             fpd.setTimeout(step.getTimeout());
                             pd = fpd;
+                        } else if (p instanceof RabbitMQMessagingProvider) {
+                            RabbitMQSubscriberProviderData rpd = new RabbitMQSubscriberProviderData(step.getProviderName());
+                            rpd.setOverrides(step.getOverrides());
+                            rpd.setChecks(step.getChecks());
+                            rpd.setTimeout(step.getTimeout());
+                            pd = rpd;
                         }
-                        CIMessageSubscriberBuilder subscriber = new CIMessageSubscriberBuilder(pd);
+                    CIMessageSubscriberBuilder subscriber = new CIMessageSubscriberBuilder(pd);
                         StepContext c = getContext();
                         String result = subscriber.waitforCIMessage(c.get(Run.class), c.get(Launcher.class), c.get(TaskListener.class));
                         if (result != null) {

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQProviderData.java
@@ -1,0 +1,36 @@
+package com.redhat.jenkins.plugins.ci.provider.data;
+
+import com.redhat.jenkins.plugins.ci.messaging.MessagingProviderOverrides;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public abstract class RabbitMQProviderData extends ProviderData {
+
+
+    private static final long serialVersionUID = -2179136601230421113L;
+
+    protected MessagingProviderOverrides overrides;
+
+    public RabbitMQProviderData() {}
+
+    public RabbitMQProviderData(String name, MessagingProviderOverrides overrides) {
+        super(name);
+        this.overrides = overrides;
+    }
+
+    public MessagingProviderOverrides getOverrides() {
+        return overrides;
+    }
+
+    @DataBoundSetter
+    public void setOverrides(MessagingProviderOverrides overrides) {
+        this.overrides = overrides;
+    }
+
+    public boolean hasOverrides() {
+        return false;
+    }
+
+    public abstract static class RabbitMQProviderDataDescriptor extends ProviderDataDescriptor {
+    }
+
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData.java
@@ -1,0 +1,145 @@
+package com.redhat.jenkins.plugins.ci.provider.data;
+
+import com.redhat.jenkins.plugins.ci.messaging.MessagingProviderOverrides;
+import com.redhat.utils.MessageUtils;
+import com.redhat.utils.MessageUtils.MESSAGE_TYPE;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
+    private static final long serialVersionUID = -2179136605130421113L;
+
+    private String messageContent;
+    private Boolean failOnError = false;
+
+    @DataBoundConstructor
+    public RabbitMQPublisherProviderData() {
+    }
+
+    public RabbitMQPublisherProviderData(String name) {
+        this(name, null);
+    }
+
+    @Override
+    public String getSubscriberTopic() {
+        return "";
+    }
+
+    @Override
+    public String getPublisherTopic() {
+        return "";
+    }
+
+    public RabbitMQPublisherProviderData(String name, MessagingProviderOverrides overrides) {
+        super(name, overrides);
+    }
+
+    public RabbitMQPublisherProviderData(String name, MessagingProviderOverrides overrides, String messageContent, Boolean failOnError) {
+        this(name, overrides);
+        this.messageContent = messageContent;
+        this.failOnError = failOnError;
+    }
+
+    public String getMessageContent() {
+        return messageContent;
+    }
+
+    @DataBoundSetter
+    public void setMessageContent(String messageContent) {
+        this.messageContent = messageContent;
+    }
+
+    public Boolean isFailOnError() {
+        return failOnError;
+    }
+
+    @DataBoundSetter
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
+    }
+
+    @Override
+    public Descriptor<ProviderData> getDescriptor() {
+        return Jenkins.getInstance().getDescriptorByType(RabbitMQPublisherProviderDataDescriptor.class);
+    }
+
+    @Override
+    public boolean equals(Object that){
+        if (!super.equals(that)) {
+            return false;
+        }
+
+        RabbitMQPublisherProviderData thatp = (RabbitMQPublisherProviderData)that;
+        return (this.name != null ? this.name.equals(thatp.name) : thatp.name == null) &&
+               (this.overrides != null ? this.overrides.equals(thatp.overrides) : thatp.overrides == null) &&
+               (this.messageContent != null ? this.messageContent.equals(thatp.messageContent) : thatp.messageContent == null) &&
+               (this.failOnError != null ? this.failOnError.equals(thatp.failOnError) : thatp.failOnError == null);
+    }
+
+    @Extension
+    @Symbol("rabbitMQPublisher")
+    public static class RabbitMQPublisherProviderDataDescriptor extends RabbitMQProviderDataDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "RabbitMQ Publisher Provider Data";
+        }
+
+        @Override
+        public RabbitMQPublisherProviderData newInstance(StaplerRequest sr, JSONObject jo) {
+            MessagingProviderOverrides mpo = null;
+            if (!jo.getJSONObject("overrides").isNullObject()) {
+                mpo = new MessagingProviderOverrides(jo.getJSONObject("overrides").getString("topic"));
+            }
+            return new RabbitMQPublisherProviderData(
+                    jo.getString("name"),
+                    mpo,
+                    jo.getString("messageContent"),
+                    jo.getBoolean("failOnError"));
+        }
+
+        public ListBoxModel doFillMessageTypeItems(@QueryParameter String messageType) {
+            return MessageUtils.doFillMessageTypeItems(messageType);
+        }
+
+        public MESSAGE_TYPE getDefaultMessageType() {
+            return DEFAULT_MESSAGE_TYPE;
+        }
+
+        public String getConfigPage() {
+            return "rabbitmq-publisher.jelly";
+        }
+
+    }
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData.java
@@ -1,0 +1,194 @@
+package com.redhat.jenkins.plugins.ci.provider.data;
+
+import com.redhat.jenkins.plugins.ci.messaging.MessagingProviderOverrides;
+import com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+public class RabbitMQSubscriberProviderData extends RabbitMQProviderData {
+    private static final long serialVersionUID = -2179136605130421113L;
+
+    public static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
+    public static final Integer DEFAULT_TIMEOUT_IN_MINUTES = 60;
+
+    private List<MsgCheck> checks = new ArrayList<MsgCheck>();
+    private String variable;
+    private Integer timeout = DEFAULT_TIMEOUT_IN_MINUTES;
+
+    @DataBoundConstructor
+    public RabbitMQSubscriberProviderData() {}
+
+    public RabbitMQSubscriberProviderData(String name) {
+        this(name, null);
+    }
+
+    @Override
+    public String getSubscriberTopic() {
+        return "";
+    }
+
+    @Override
+    public String getPublisherTopic() {
+        return "";
+    }
+
+    public RabbitMQSubscriberProviderData(String name, MessagingProviderOverrides overrides) {
+        super(name, overrides);
+    }
+
+    public RabbitMQSubscriberProviderData(String name, MessagingProviderOverrides overrides, List<MsgCheck> checks, String variable, Integer timeout) {
+        this(name, overrides);
+        this.checks = checks;
+        this.variable = variable;
+        this.timeout = timeout;
+    }
+
+
+    public List<MsgCheck> getChecks() {
+        return checks;
+    }
+
+    @DataBoundSetter
+    public void setChecks(List<MsgCheck> checks) {
+        this.checks = checks;
+    }
+
+    public String getVariable() {
+        return variable;
+    }
+
+    @DataBoundSetter
+    public void setVariable(String variable) {
+        this.variable = variable;
+    }
+
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    @DataBoundSetter
+    public void setTimeout(Integer timeout) {
+        this.timeout = timeout;
+    }
+
+    @Override
+    public Descriptor<ProviderData> getDescriptor() {
+        return Jenkins.getInstance().getDescriptorByType(RabbitMQSubscriberProviderDataDescriptor.class);
+    }
+
+    @Override
+    public boolean equals(Object that){
+        if (!super.equals(that)) {
+            return false;
+        }
+
+        RabbitMQSubscriberProviderData thatp = (RabbitMQSubscriberProviderData)that;
+        return (this.name != null ? this.name.equals(thatp.name) : thatp.name == null) &&
+               (this.overrides != null ? this.overrides.equals(thatp.overrides) : thatp.overrides == null) &&
+               (this.checks != null ? this.checks.equals(thatp.checks) : thatp.checks == null) &&
+               (this.variable != null ? this.variable.equals(thatp.variable) : thatp.variable == null) &&
+               (this.timeout != null ? this.timeout.equals(thatp.timeout) : thatp.timeout == null);
+    }
+
+    @Extension
+    @Symbol("rabbitMQSubscriber")
+    public static class RabbitMQSubscriberProviderDataDescriptor extends RabbitMQProviderDataDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "RabbitMQ Subscriber Provider Data";
+        }
+
+        @Override
+        public RabbitMQSubscriberProviderData newInstance(StaplerRequest sr, JSONObject jo) {
+            MessagingProviderOverrides mpo = null;
+            if (!jo.getJSONObject("overrides").isNullObject()) {
+                mpo = new MessagingProviderOverrides(jo.getJSONObject("overrides").getString("topic"));
+                mpo.setQueue(jo.getJSONObject("overrides").getString("queue"));
+            }
+            List<MsgCheck> checks = sr.bindJSONToList(MsgCheck.class, jo.get("checks"));
+            String variable = null;
+            if (jo.has("variable")) {
+                variable = jo.getString("variable");
+            }
+            Integer timeout = null;
+            if (jo.has("timeout") && !StringUtils.isEmpty(jo.getString("timeout"))) {
+                timeout = jo.getInt("timeout");
+            }
+            return new RabbitMQSubscriberProviderData(jo.getString("name"), mpo, checks, variable, timeout);
+        }
+
+        public String getDefaultVariable() {
+            return DEFAULT_VARIABLE_NAME;
+        }
+
+        public Integer getDefaultTimeout() {
+            return DEFAULT_TIMEOUT_IN_MINUTES;
+        }
+
+        public FormValidation doCheckSelector(@QueryParameter String selector) {
+            if (selector == null || selector.isEmpty()) {
+                return FormValidation.error("Please enter a JMS selector.");
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckVariable(@QueryParameter String variable) {
+            if (variable == null || variable.isEmpty()) {
+                return FormValidation.error("Please enter a variable name to hold the received message result.");
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckTimeout(@QueryParameter String timeout) {
+            try {
+                if (timeout == null || timeout.isEmpty() || Integer.parseInt(timeout) <= 0) {
+                    return FormValidation.error("Please enter a positive timeout value.");
+                }
+            } catch (NumberFormatException e) {
+                return FormValidation.error("Please enter a valid timeout value.");
+            }
+            return FormValidation.ok();
+        }
+
+        public String getConfigPage() {
+            return "rabbitmq-subscriber.jelly";
+        }
+
+    }
+}

--- a/src/main/java/com/redhat/jenkins/plugins/ci/threads/RabbitMqTriggerThread.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/threads/RabbitMqTriggerThread.java
@@ -1,0 +1,36 @@
+package com.redhat.jenkins.plugins.ci.threads;
+
+import com.redhat.jenkins.plugins.ci.CIBuildTrigger;
+import com.redhat.jenkins.plugins.ci.messaging.JMSMessagingProvider;
+import com.redhat.jenkins.plugins.ci.messaging.RabbitMQMessagingWorker;
+import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RabbitMqTriggerThread extends CITriggerThread {
+    private static final Logger log = Logger.getLogger(RabbitMqTriggerThread.class.getName());
+
+    private RabbitMQMessagingWorker worker;
+
+    public RabbitMqTriggerThread(JMSMessagingProvider messagingProvider, ProviderData providerData, String jobname, CIBuildTrigger cibt, int instance) {
+        super(messagingProvider, providerData, jobname, cibt, instance);
+        worker = (RabbitMQMessagingWorker)messagingWorker;
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            worker.prepareForInterrupt();
+            interrupt();
+            join();
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Unhandled exception in RabbitMQ trigger stop.", e);
+        }
+    }
+
+    public boolean hasBeenInterrupted() {
+        return !Thread.currentThread().isInterrupted() && worker.isBeingInterrupted();
+    }
+}

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keypwd.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keypwd.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Key store file password.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keystore.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-keystore.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Key store file to use to connect to the CI topic.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-trustpwd.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-trustpwd.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Trust store file password.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-truststore.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-truststore.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Trust store file to use to connect to the CI topic.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-username.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/help-username.html
@@ -1,0 +1,3 @@
+<div>
+  <p>User name to use to connect to the CI exchange. Should be same as in provided certificates.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/sslcert.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/SSLCertificateAuthenticationMethod/SSLCertificateAuthenticationMethodDescriptor/sslcert.jelly
@@ -1,0 +1,46 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+      <f:nested>
+        <f:entry title="${%User name}" field="username">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Key store}" field="keystore">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Key store password}" field="keypwd">
+          <f:password />
+        </f:entry>
+        <f:entry title="${%Trust store}" field="truststore">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Trust store password}" field="trustpwd">
+          <f:password />
+        </f:entry>
+        <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection"
+         with="hostname,portNumber,virtualHost,keystore,keypwd,truststore,trustpwd" />
+      </f:nested>
+</j:jelly>
+

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-password.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-password.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Password to use to connect to the CI exchange.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-username.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/help-username.html
@@ -1,0 +1,3 @@
+<div>
+  <p>User name to use to connect to the CI exchange.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/username.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/authentication/rabbitmq/UsernameAuthenticationMethod/UsernameAuthenticationMethodDescriptor/username.jelly
@@ -1,0 +1,37 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+      <f:nested>
+        <f:entry title="${%User name}" field="username">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="${%Password}" field="password">
+          <f:password />
+        </f:entry>
+        <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection"
+         with="hostname,portNumber,virtualHost,username,password" />
+      </f:nested>
+</j:jelly>
+

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/integration/docker/fixtures/RabbitMQRelayContainer/Dockerfile
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/integration/docker/fixtures/RabbitMQRelayContainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM fedora:30
+
+RUN dnf install -y rabbitmq-server
+
+RUN mkdir /etc/systemd/system/rabbitmq-server.service.d/
+COPY override.conf /etc/systemd/system/rabbitmq-server.service.d/override.conf
+
+EXPOSE 5672
+
+ENTRYPOINT ["rabbitmq-server"]

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/integration/docker/fixtures/RabbitMQRelayContainer/override.conf
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/integration/docker/fixtures/RabbitMQRelayContainer/override.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE={{rabbitmq_cluster_file_limit}}

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/config.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/config.jelly
@@ -1,0 +1,55 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+    <?jelly escape-by-default='true'?>
+    <f:section title="Connection Properties">
+    <f:entry title="Name" field="name">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Hostname}" field="hostname">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Port Number}" field="portNumber">
+      <f:number />
+    </f:entry>
+    <f:entry title="${%Virtual Host}" field="virtualHost">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Topic}" field="topic">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Exchange}" field="exchange">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Queue}" field="queue">
+      <f:textbox />
+    </f:entry>
+    <f:dropdownDescriptorSelector name="authenticationMethod"
+                                  title="${%Authentication Method}"
+                                  field="authenticationMethod"
+                                  descriptors="${descriptor.getAuthenticationMethodDescriptors()}" />
+ </f:section>
+</j:jelly>
+

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-authenticationMethod.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-authenticationMethod.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Authentication method to use when connecting to RabbitMQ server.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-exchange.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-exchange.html
@@ -1,0 +1,3 @@
+<div>
+  <p>RabbitMQ exchange to use for this provider.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-hostname.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-hostname.html
@@ -1,0 +1,3 @@
+<div>
+  <p>RabbiMQ server hostname.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-name.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-name.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Name of the provider.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-portNumber.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-portNumber.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Port where RabbitMQ server is listening.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-queue.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-queue.html
@@ -1,0 +1,7 @@
+<div>
+  <p>Global queue used for RabbitMQ messages.</p>
+
+  <p>This queue is for notifier as default.</p>
+
+  <p>Could be overridden in configuration of specific notifier.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-topic.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-topic.html
@@ -1,0 +1,7 @@
+<div>
+  <p>Global topic used for RabbitMQ messages.</p>
+
+  <p>This topic is used both for subscriber and notifier as default.</p>
+
+  <p>Could be overridden in configuration of specific subscriber or notifier.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-virtualHost.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingProvider/help-virtualHost.html
@@ -1,0 +1,3 @@
+<div>
+  <p>RabbiMQ server virtual host.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQSubscriberProviderData/help-queue.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQSubscriberProviderData/help-queue.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    Queue to subscribe to using the RabbitMQ provider.
+    This queue must exist on broker, otherwise subscribing fail.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/RabbitMQPublisherProviderDataDescriptor/rabbitmq-publisher.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/RabbitMQPublisherProviderDataDescriptor/rabbitmq-publisher.jelly
@@ -1,0 +1,54 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:rh="/com/redhat/jenkins/plugins/ci/CIMessageSubscriberBuilder/form">
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     */
+  -->
+  <f:nested>
+    <j:choose>
+      <j:when test="${empty(instance)}">
+        <j:set var="checked" value="${pdata.hasOverrides();}"/>
+        <j:set var="value" value="${pdata.getPublisherTopic();}"/>
+        <j:set var="name" value="${pdata.getName();}"/>
+      </j:when>
+      <j:otherwise>
+        <j:set var="checked" value="${instance.getOverrides() != null}"/>
+        <j:set var="value" value="${instance.getOverrides().getTopic();}"/>
+        <j:set var="name" value="${instance.getName();}"/>
+      </j:otherwise>
+    </j:choose>
+    <table width="100%">
+      <f:optionalBlock field="overrides" title="Override provider topic" checked="${checked}">
+        <f:entry title="${%Topic name}" field="topic">
+          <f:textbox value="${value}"/>
+        </f:entry>
+      </f:optionalBlock>
+    </table>
+  </f:nested>
+  <f:entry title="${%Message content}" field="messageContent">
+    <f:textarea name="messageContent"/>
+  </f:entry>
+  <f:entry field="failOnError">
+    <f:checkbox title="${%Fail on error}" name="failOnError" default="false"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-failOnError.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-failOnError.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Whether you want to fail the build if there is an error sending a message. By default, it is false.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-messageContent.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-messageContent.html
@@ -1,0 +1,5 @@
+<div>
+  <p>Content of CI message to be sent. Environment variable values may be used in the content to allow customization
+     of the message. Environment variables should use the familiar bash shell format, e.g. ${VARIABLE}.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-topic.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-topic.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Topic to send the message to using the specified provider. You can specify variables such as $MY_TOPIC
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/RabbitMQSubscriberProviderDataDescriptor/rabbitmq-subscriber.jelly
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/RabbitMQSubscriberProviderDataDescriptor/rabbitmq-subscriber.jelly
@@ -1,0 +1,81 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <!--
+     * The MIT License
+     *
+     * Copyright (c) Red Hat, Inc.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     * copies of the Software, and to permit persons to whom the Software is
+     * furnished to do so, subject to the following conditions:
+     *
+     * The above copyright notice and this permission notice shall be included in
+     * all copies or substantial portions of the Software.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+     * THE SOFTWARE.
+     *
+  -->
+
+  <f:nested>
+    <j:choose>
+      <j:when test="${empty(instance)}">
+        <j:set var="checked" value="${pdata.hasOverrides();}"/>
+        <j:set var="topic" value="${pdata.getSubscriberTopic();}"/>
+        <j:set var="queue" value=""/>
+        <j:set var="name" value="${pdata.getName();}"/>
+      </j:when>
+      <j:otherwise>
+        <j:set var="checked" value="${instance.getOverrides() != null}"/>
+        <j:set var="topic" value="${instance.getOverrides().getTopic();}"/>
+        <j:set var="queue" value="${instance.getOverrides().getQueue();}"/>
+        <j:set var="name" value="${instance.getName();}"/>
+      </j:otherwise>
+    </j:choose>
+    <table width="100%">
+      <f:optionalBlock field="overrides" title="Override provider fields" checked="${checked}">
+        <f:entry title="${%Topic name}" field="topic">
+          <f:textbox value="${topic}"/>
+        </f:entry>
+        <f:entry title="${%Queue name}" field="queue">
+          <f:textbox value="${queue}"/>
+        </f:entry>
+      </f:optionalBlock>
+    </table>
+    <f:entry title="${%Message Checks}" help="/plugin/jms-messaging/help-checks.html">
+        <f:repeatable var="check" name="checks" items="${instance.checks}" add="${%Add check}" minimum="0">
+          <table width="100%">
+            <f:entry title="${%Field}">
+              <f:textbox name="checks.field" value="${check.field}"
+                         checkUrl="'descriptorByName/com.redhat.jenkins.plugins.ci.CIBuildTrigger/checkField?value='+escape(this.value)" />
+            </f:entry>
+            <f:entry title="${%Expected value}">
+              <f:textbox name="checks.expectedValue" value="${check.expectedValue}" />
+            </f:entry>
+            <f:entry>
+              <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                <f:repeatableDeleteButton value="${%Delete check}" />
+                <br/>
+              </div>
+            </f:entry>
+        </table>
+      </f:repeatable>
+    </f:entry>
+    <j:if test="${desc.getClass().getSimpleName() != 'CIBuildTriggerDescriptor'}">
+      <f:entry title="${%Variable}" field="variable">
+        <f:textbox default="${descriptor.getDefaultVariable()}"/>
+      </f:entry>
+      <f:entry title="${%Timeout}" field="timeout">
+        <f:textbox default="${descriptor.getDefaultTimeout()}"/>
+      </f:entry>
+    </j:if>
+  </f:nested>
+</j:jelly>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-timeout.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-timeout.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Value (in minutes) to wait for a message.</p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-topic.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-topic.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Topic to subscribe to using the specified provider.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-variable.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData/help-variable.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Environment variable to hold received message content.</p>
+</div>

--- a/src/test/java/com/redhat/jenkins/plugins/ci/integration/RabbitMQMessagingPluginIntegrationTest.java
+++ b/src/test/java/com/redhat/jenkins/plugins/ci/integration/RabbitMQMessagingPluginIntegrationTest.java
@@ -1,0 +1,318 @@
+package com.redhat.jenkins.plugins.ci.integration;
+
+import com.google.inject.Inject;
+import com.redhat.jenkins.plugins.ci.integration.docker.fixtures.FedmsgRelayContainer;
+import com.redhat.jenkins.plugins.ci.integration.docker.fixtures.RabbitMQRelayContainer;
+import com.redhat.jenkins.plugins.ci.integration.po.*;
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matchers;
+import org.jenkinsci.test.acceptance.docker.DockerContainerHolder;
+import org.jenkinsci.test.acceptance.junit.WithDocker;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.jenkinsci.test.acceptance.po.WorkflowJob;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.jenkinsci.test.acceptance.Matchers.hasContent;
+import static org.junit.Assert.assertTrue;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@WithPlugins({"jms-messaging", "dumpling"})
+@WithDocker
+public class RabbitMQMessagingPluginIntegrationTest extends SharedMessagingPluginIntegrationTest {
+    @Inject private DockerContainerHolder<RabbitMQRelayContainer> docker;
+
+    private RabbitMQRelayContainer rabbitmq = null;
+    private static final int INIT_WAIT = 360;
+
+    @Test
+    public void testGlobalConfigTestConnection() throws Exception {
+    }
+
+    @Test
+    public void testAddDuplicateMessageProvider() throws IOException {
+        jenkins.configure();
+        GlobalCIConfiguration ciPluginConfig = new GlobalCIConfiguration(jenkins.getConfigPage());
+        RabbitMQMessagingProvider msgConfig = new RabbitMQMessagingProvider(ciPluginConfig).addMessagingProvider();
+        msgConfig.name("test")
+                .hostname(rabbitmq.getHost())
+                .portNumber(rabbitmq.getPort())
+                .virtualHost("/")
+                .topic("CI")
+                .exchange("amq.fanout")
+                .queue("")
+                .userNameAuthentication("guest", "guest");
+        _testAddDuplicateMessageProvider();
+    }
+
+    @Test
+    public void testSimpleCIEventSubscribeWithCheck() throws Exception {
+        _testSimpleCIEventSubscribeWithCheck();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithTextArea() {
+        _testSimpleCIEventTriggerWithTextArea("{ \"message\": \"Hello\\nWorld\" }",
+                "Hello\\nWorld");
+    }
+
+    @Test
+    public void testSimpleCIEventSubscribeWithCheckWithTopicOverride() throws Exception, InterruptedException {
+        _testSimpleCIEventSubscribeWithCheckWithTopicOverride();
+    }
+
+    @Test
+    public void testSimpleCIEventSubscribeWithCheckWithTopicOverrideAndVariableTopic() throws Exception {
+        _testSimpleCIEventSubscribeWithCheckWithTopicOverrideAndVariableTopic();
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testSimpleCIEventTriggerWithCheckWithPipelineSendMsg() throws Exception {
+        _testSimpleCIEventTriggerWithCheckWithPipelineSendMsg();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithCheck() throws Exception {
+        _testSimpleCIEventTriggerWithCheck();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithCheckNoSquash() throws Exception {
+        _testSimpleCIEventTriggerWithCheckNoSquash();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithRegExpCheck() throws Exception {
+        _testSimpleCIEventTriggerWithRegExpCheck();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithCheckWithTopicOverride() throws Exception {
+        _testSimpleCIEventTriggerWithCheckWithTopicOverride();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithMultipleTopics() throws Exception {
+        _testSimpleCIEventTriggerWithMultipleTopics();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithCheckWithTopicOverrideAndVariableTopic() throws Exception {
+        _testSimpleCIEventTriggerWithCheckWithTopicOverrideAndVariableTopic();
+    }
+
+    @Test
+    public void testSimpleCIEventTriggerWithCheckWithTopicOverrideAndRestart() throws Exception {
+        _testSimpleCIEventTriggerWithCheckWithTopicOverrideAndRestart();
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testSimpleCIEventTriggerWithCheckOnPipelineJob() throws Exception {
+        _testSimpleCIEventTriggerWithCheckOnPipelineJob();
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testSimpleCIEventTriggerWithCheckWithPipelineWaitForMsg() throws Exception {
+        _testSimpleCIEventTriggerWithCheckWithPipelineWaitForMsg();
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testSimpleCIEventSendAndWaitPipeline() throws Exception {
+        WorkflowJob wait = jenkins.jobs.create(WorkflowJob.class);
+        wait.script.set("node('master') {\n def scott = waitForCIMessage providerName: 'test'," +
+                " topic: 'org.fedoraproject.otopic'" +
+                "\necho \"scott = \" + scott}");
+        wait.save();
+        wait.startBuild();
+
+        WorkflowJob send = jenkins.jobs.create(WorkflowJob.class);
+        send.configure();
+        send.script.set("node('master') {\n sendCIMessage" +
+                " providerName: 'test', " +
+                " topic: 'org.fedoraproject.otopic'," +
+                " messageContent: '{\"content\":\"abcdefg\"}'}");
+        send.save();
+        send.startBuild().shouldSucceed();
+
+        String expected = "scott = {\"content\":\"abcdefg\"}";
+        elasticSleep(1000);
+        wait.getLastBuild().shouldSucceed();
+        assertThat(wait.getLastBuild().getConsole(), containsString(expected));
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testSimpleCIEventSendAndWaitPipelineWithVariableTopic() throws Exception {
+        WorkflowJob wait = jenkins.jobs.create(WorkflowJob.class);
+        wait.script.set("node('master') {\n" +
+                "    env.MY_TOPIC = 'org.fedoraproject.my-topic'\n" +
+                "    def scott = waitForCIMessage providerName: \"test\", overrides: [topic: \"${env.MY_TOPIC}\"]\n" +
+                "    echo \"scott = \" + scott\n" +
+                "}");
+        wait.save();
+        wait.startBuild();
+
+        WorkflowJob send = jenkins.jobs.create(WorkflowJob.class);
+        send.configure();
+        send.script.set("node('master') {\n" +
+                " env.MY_TOPIC = 'org.fedoraproject.my-topic'\n" +
+                " sendCIMessage providerName: \"test\", overrides: [topic: \"${env.MY_TOPIC}\"], messageContent: '{ \"content\" : \"abcdef\" }'\n" +
+                "}");
+        send.save();
+        send.startBuild().shouldSucceed();
+
+        String expected = "scott = {\"content\":\"abcdef\"}";
+        elasticSleep(1000);
+        wait.getLastBuild().shouldSucceed();
+        assertThat(wait.getLastBuild().getConsole(), containsString(expected));
+    }
+
+    @Test
+    public void testJobRenameWithCheck() throws Exception {
+        _testJobRenameWithCheck();
+    }
+
+    @Test
+    public void testDisabledJobDoesNotGetTriggeredWithCheck() throws Exception {
+        _testDisabledJobDoesNotGetTriggeredWithCheck();
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testSimpleCIEventTriggerWithCheckOnPipelineJobWithGlobalEnvVarInTopic() throws Exception {
+        _testSimpleCIEventTriggerWithCheckOnPipelineJobWithGlobalEnvVarInTopic();
+    }
+
+    // RabbitMQ doesn't use MessageType or MessageProperties, so this test doesn't work
+    //@Test
+    //public void testEnsureFailedSendingOfMessageFailsBuild() throws Exception {
+    //}
+
+    // RabbitMQ doesn't use MessageType or MessageProperties, so this test doesn't work
+    //@WithPlugins("workflow-aggregator")
+    //@Test
+    //public void testEnsureFailedSendingOfMessageFailsPipelineBuild() throws Exception {
+    //}
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testAbortWaitingForMessageWithPipelineBuild() throws Exception {
+        _testAbortWaitingForMessageWithPipelineBuild();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        rabbitmq = docker.get();
+        jenkins.configure();
+        elasticSleep(5000);
+        GlobalCIConfiguration ciPluginConfig = new GlobalCIConfiguration(jenkins.getConfigPage());
+        RabbitMQMessagingProvider msgConfig = new RabbitMQMessagingProvider(ciPluginConfig).addMessagingProvider();
+        msgConfig.name("test")
+                .hostname(rabbitmq.getHost())
+                .portNumber(rabbitmq.getPort())
+                .virtualHost("/")
+                .topic("CI")
+                .exchange("amq.fanout")
+                .queue("")
+                .userNameAuthentication("guest", "guest");
+
+        int counter = 0;
+        boolean connected = false;
+        while (counter < INIT_WAIT) {
+            try {
+                msgConfig.testConnection();
+                waitFor(driver, hasContent("Successfully connected to " + rabbitmq.getHost() + ":" + rabbitmq.getPort()), 5);
+                connected = true;
+                break;
+            } catch (Exception e) {
+                counter++;
+                elasticSleep(1000);
+            }
+        }
+        if (!connected) {
+            throw new Exception("Did not get connection successful message in " + INIT_WAIT + " secs.");
+        }
+        elasticSleep(1000);
+        jenkins.save();
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testPipelineInvalidProvider() throws Exception {
+        _testPipelineInvalidProvider();
+    }
+
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testPipelineSendMsgReturnMessage() throws Exception {
+        WorkflowJob job = jenkins.jobs.create(WorkflowJob.class);
+        job.script.set("node('master') {\n def message = sendCIMessage " +
+                " providerName: 'test', " +
+                " messageContent: '', " +
+                " messageProperties: 'CI_STATUS = failed'," +
+                " messageType: 'CodeQualityChecksDone'\n"  +
+                " echo message.getMessageId()\necho message.getMessageContent()\n}");
+        job.sandbox.check(true);
+        job.save();
+        job.startBuild().shouldSucceed();
+        // See https://github.com/jenkinsci/jms-messaging-plugin/issues/125
+        // timestamp == 0 indicates timestamp was not set in message
+        assertThat(job.getLastBuild().getConsole(), Matchers.not(containsString("\"timestamp\":0")));
+    }
+
+    @Test
+    public void testSimpleCIEventSubscribeWithQueueOverride() throws Exception, InterruptedException {
+        FreeStyleJob job = jenkins.jobs.create();
+        job.configure();
+
+        CISubscriberBuildStep subscriber = job.addBuildStep(CISubscriberBuildStep.class);
+        subscriber.overrides.check();
+        subscriber.queue.set("queue");
+
+        job.save();
+        elasticSleep(1000);
+        job.scheduleBuild();
+        job.getLastBuild().shouldFail().shouldExist();
+        assertThat(job.getLastBuild().getConsole(), containsString("ERROR: Connection to broker can't be established!"));
+    }
+}

--- a/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/CISubscriberBuildStep.java
+++ b/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/CISubscriberBuildStep.java
@@ -36,6 +36,7 @@ public class CISubscriberBuildStep extends AbstractStep implements BuildStep {
     public final Control providerData = control("/");
     public final Control overrides = control("providerData/overrides");
     public final Control topic = control("providerData/overrides/topic");
+    public final Control queue = control("providerData/overrides/queue");
     public final Control selector = control("providerData/selector");
     public final Control checks = control("providerData/repeatable-add");
     public final Control variable = control("providerData/variable");

--- a/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/RabbitMQMessagingProvider.java
+++ b/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/RabbitMQMessagingProvider.java
@@ -1,0 +1,112 @@
+package com.redhat.jenkins.plugins.ci.integration.po;
+
+import org.jenkinsci.test.acceptance.po.Control;
+import org.jenkinsci.test.acceptance.po.Describable;
+import org.jenkinsci.test.acceptance.po.PageObject;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@Describable("RabbitMQ")
+public class RabbitMQMessagingProvider extends MessagingProvider {
+
+    public final Control name           = control("name");
+    public final Control hostname       = control("hostname");
+    public final Control portNumber     = control("portNumber");
+    public final Control virtualHost    = control("virtualHost");
+    public final Control topic          = control("topic");
+    public final Control exchange       = control("exchange");
+    public final Control queue          = control("queue");
+
+    public RabbitMQMessagingProvider(PageObject parent, String path) {
+        super(parent, path);
+    }
+
+    public RabbitMQMessagingProvider(GlobalCIConfiguration context) {
+        super(context);
+    }
+
+    public RabbitMQMessagingProvider name(String nameVal) {
+        name.set(nameVal);
+        return this;
+    }
+    public RabbitMQMessagingProvider hostname(String hostnameVal) {
+        hostname.set(hostnameVal);
+        return this;
+    }
+    public RabbitMQMessagingProvider portNumber(String portNumberVal) {
+        portNumber.set(portNumberVal);
+        return this;
+    }
+    public RabbitMQMessagingProvider virtualHost(String virtualHostVal) {
+        virtualHost.set(virtualHostVal);
+        return this;
+    }
+    public RabbitMQMessagingProvider topic(String topicVal) {
+        topic.set(topicVal);
+        return this;
+    }
+    public RabbitMQMessagingProvider exchange(String exchangeVal) {
+        exchange.set(exchangeVal);
+        return this;
+    }
+    public RabbitMQMessagingProvider queue(String queueVal) {
+        queue.set(queueVal);
+        return this;
+    }
+
+    public void testConnection() {
+        clickButton("Test Connection");
+    }
+
+    @Override
+    public RabbitMQMessagingProvider addMessagingProvider() {
+        String path = createPageArea("configs", new Runnable() {
+            @Override public void run() {
+                control("hetero-list-add[configs]").selectDropdownMenu(RabbitMQMessagingProvider.class);
+            }
+        });
+        return new RabbitMQMessagingProvider(getPage(), path);
+    }
+
+    public RabbitMQMessagingProvider userNameAuthentication(String user, String password) {
+        Control select = control("/");
+        select.select("1");
+        control("/authenticationMethod/username").set(user);
+        control("/authenticationMethod/password").set(password);
+        return this;
+    }
+
+    public RabbitMQMessagingProvider sslCertAuthentication(String keystore,
+                                                           String keystorePass,
+                                                           String trustStore,
+                                                           String trustStorePass) {
+        Control select = control("/");
+        select.select("0");
+        control("/authenticationMethod/keystore").set(keystore);
+        control("/authenticationMethod/keypwd").set(keystorePass);
+        control("/authenticationMethod/truststore").set(trustStore);
+        control("/authenticationMethod/trustpwd").set(trustStorePass);
+        return this;
+    }
+}


### PR DESCRIPTION
I'm opening this PR as continuation of #147 

This client is based on RabbitMQ Java Client.

Supports SSL and Username/Password authentication and could be
configured to work with any RabbitMQ server.

Connection to each server is created only once and separate channel is
created for each consumer and publisher.

When publishing generates message id using java.util.UUID and send this
id as property of the message.

Consuming is done using by using Push API (subscription) even when
listening for messages for a limited time.

Signed-off-by: Michal Konečný mkonecny@redhat.com