### PR TITLE
Add support for Fedora messaging wire format

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData.java
@@ -42,6 +42,10 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
 
     private String messageContent;
     private Boolean failOnError = false;
+    // Fedora messaging related fields
+    private Boolean fedoraMessaging = false;
+    private Integer severity = 20;
+    private String schema;
 
     @DataBoundConstructor
     public RabbitMQPublisherProviderData() {
@@ -65,10 +69,14 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
         super(name, overrides);
     }
 
-    public RabbitMQPublisherProviderData(String name, MessagingProviderOverrides overrides, String messageContent, Boolean failOnError) {
+    public RabbitMQPublisherProviderData(String name, MessagingProviderOverrides overrides, String messageContent,
+                                         Boolean failOnError, Boolean fedoraMessaging, Integer severity, String schema) {
         this(name, overrides);
         this.messageContent = messageContent;
         this.failOnError = failOnError;
+        this.fedoraMessaging = fedoraMessaging;
+        this.severity = severity;
+        this.schema = schema;
     }
 
     public String getMessageContent() {
@@ -89,6 +97,33 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
         this.failOnError = failOnError;
     }
 
+    public Boolean isFedoraMessaging() {
+        return fedoraMessaging;
+    }
+
+    @DataBoundSetter
+    public void setFedoraMessaging(boolean fedoraMessaging) {
+        this.fedoraMessaging = fedoraMessaging;
+    }
+
+    public Integer getSeverity() {
+        return severity;
+    }
+
+    @DataBoundSetter
+    public void setSeverity(Integer severity) {
+        this.severity = severity;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    @DataBoundSetter
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
     @Override
     public Descriptor<ProviderData> getDescriptor() {
         return Jenkins.getInstance().getDescriptorByType(RabbitMQPublisherProviderDataDescriptor.class);
@@ -104,7 +139,9 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
         return (this.name != null ? this.name.equals(thatp.name) : thatp.name == null) &&
                (this.overrides != null ? this.overrides.equals(thatp.overrides) : thatp.overrides == null) &&
                (this.messageContent != null ? this.messageContent.equals(thatp.messageContent) : thatp.messageContent == null) &&
-               (this.failOnError != null ? this.failOnError.equals(thatp.failOnError) : thatp.failOnError == null);
+               (this.failOnError != null ? this.failOnError.equals(thatp.failOnError) : thatp.failOnError == null) &&
+               (this.fedoraMessaging != null ? this.fedoraMessaging.equals(thatp.fedoraMessaging) : thatp.fedoraMessaging == null) &&
+               (this.schema != null ? this.schema.equals(thatp.schema) : thatp.schema == null);
     }
 
     @Extension
@@ -119,14 +156,25 @@ public class RabbitMQPublisherProviderData extends RabbitMQProviderData {
         @Override
         public RabbitMQPublisherProviderData newInstance(StaplerRequest sr, JSONObject jo) {
             MessagingProviderOverrides mpo = null;
+            Boolean fedoraMessaging = false;
+            Integer severity = 20;
+            String schema = "";
             if (!jo.getJSONObject("overrides").isNullObject()) {
                 mpo = new MessagingProviderOverrides(jo.getJSONObject("overrides").getString("topic"));
+            }
+            if (!jo.getJSONObject("fedoraMessagingFields").isNullObject()) {
+                fedoraMessaging = true;
+                severity = jo.getJSONObject("fedoraMessagingFields").getInt("severity");
+                schema = jo.getJSONObject("fedoraMessagingFields").getString("schema");
             }
             return new RabbitMQPublisherProviderData(
                     jo.getString("name"),
                     mpo,
                     jo.getString("messageContent"),
-                    jo.getBoolean("failOnError"));
+                    jo.getBoolean("failOnError"),
+                    fedoraMessaging,
+                    severity,
+                    schema);
         }
 
         public ListBoxModel doFillMessageTypeItems(@QueryParameter String messageType) {

--- a/plugin/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/RabbitMQPublisherProviderDataDescriptor/rabbitmq-publisher.jelly
+++ b/plugin/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/RabbitMQPublisherProviderDataDescriptor/rabbitmq-publisher.jelly
@@ -31,11 +31,16 @@
         <j:set var="checked" value="${pdata.hasOverrides();}"/>
         <j:set var="value" value="${pdata.getPublisherTopic();}"/>
         <j:set var="name" value="${pdata.getName();}"/>
+        <j:set var="fedoraMessaging" value="${pdata.isFedoraMessaging();}"/>
+        <j:set var="severity" value="${pdata.getSeverity();}"/>
+        <j:set var="schema" value="${pdata.getSchema();}"/>
       </j:when>
       <j:otherwise>
         <j:set var="checked" value="${instance.getOverrides() != null}"/>
         <j:set var="value" value="${instance.getOverrides().getTopic();}"/>
         <j:set var="name" value="${instance.getName();}"/>
+        <j:set var="fedoraMessaging" value="false"/>
+        <j:set var="severity" value="20"/>
       </j:otherwise>
     </j:choose>
     <table width="100%">
@@ -52,4 +57,21 @@
   <f:entry field="failOnError">
     <f:checkbox title="${%Fail on error}" name="failOnError" default="false"/>
   </f:entry>
+  <f:nested>
+    <table width="100%">
+      <f:optionalBlock field="fedoraMessagingFields" title="Fedora messaging header fields" checked="${fedoraMessaging}">
+        <f:entry title="${%Severity}" field="severity">
+            <select name="severity" value="${severity}">
+                <option value="10">Debug</option>
+                <option value="20">Info</option>
+                <option value="30">Warning</option>
+                <option value="40">Critical</option>
+            </select>
+        </f:entry>
+        <f:entry title="${%Schema}" field="schema">
+          <f:textbox value="${schema}"/>
+        </f:entry>
+      </f:optionalBlock>
+    </table>
+  </f:nested>
 </j:jelly>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-fedoraMessagingFields.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-fedoraMessagingFields.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    Configure headers that are specific for Fedora messaging wire format. For additional info see
+    <a href="https://fedora-messaging.readthedocs.io/en/latest/wire-format.html">https://fedora-messaging.readthedocs.io/en/latest/wire-format.html</a>.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-schema.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-schema.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Path to message schema.
+  </p>
+</div>

--- a/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-severity.html
+++ b/src/main/resources/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQPublisherProviderData/help-severity.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Severity of the message.
+  </p>
+</div>

--- a/ui-tests/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/CINotifierPostBuildStep.java
+++ b/ui-tests/src/test/java/com/redhat/jenkins/plugins/ci/integration/po/CINotifierPostBuildStep.java
@@ -39,6 +39,9 @@ public class CINotifierPostBuildStep extends AbstractStep implements PostBuildSt
     public final Control messageProperties = control("providerData/messageProperties");
     public final Control messageContent = control("providerData/messageContent");
     public final Control failOnError = control("providerData/failOnError");
+    public final Control fedoraMessaging = control("providerData/fedoraMessagingFields");
+    public final Control severity = control("providerData/fedoraMessagingFields/severity");
+    public final Control schema = control("providerData/fedoraMessagingFields/schema");
 
     public CINotifierPostBuildStep(Job parent, String path) {
         super(parent, path);


### PR DESCRIPTION
Fedora messaging recently introduced wire format (see
https://fedora-messaging.readthedocs.io/en/latest/wire-format.html).
This commit adds support for the new headers.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>