### PR TITLE
WIP: Fix message too long

### DIFF
--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQSubscriberProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/ActiveMQSubscriberProviderData.java
@@ -46,7 +46,7 @@ import com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck;
 public class ActiveMQSubscriberProviderData extends ActiveMQProviderData {
     private static final long serialVersionUID = -2179136605130421113L;
 
-    public static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
+    private static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
     public static final Integer DEFAULT_TIMEOUT_IN_MINUTES = 60;
 
     private String selector;

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/FedMsgSubscriberProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/FedMsgSubscriberProviderData.java
@@ -46,7 +46,7 @@ import com.redhat.jenkins.plugins.ci.messaging.checks.MsgCheck;
 public class FedMsgSubscriberProviderData extends FedMsgProviderData {
     private static final long serialVersionUID = -2179136605130421113L;
 
-    public static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
+    private static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
     public static final Integer DEFAULT_TIMEOUT_IN_MINUTES = 60;
 
     private List<MsgCheck> checks = new ArrayList<MsgCheck>();

--- a/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/provider/data/RabbitMQSubscriberProviderData.java
@@ -43,7 +43,7 @@ import java.util.List;
 public class RabbitMQSubscriberProviderData extends RabbitMQProviderData {
     private static final long serialVersionUID = -2179136605130421113L;
 
-    public static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
+    private static final String DEFAULT_VARIABLE_NAME = "CI_MESSAGE";
     public static final Integer DEFAULT_TIMEOUT_IN_MINUTES = 60;
 
     private List<MsgCheck> checks = new ArrayList<MsgCheck>();

--- a/src/test/java/com/redhat/jenkins/plugins/ci/TriggerTest.java
+++ b/src/test/java/com/redhat/jenkins/plugins/ci/TriggerTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.redhat.jenkins.plugins.ci;
+
+import com.google.common.base.Strings;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.tasks.Shell;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+public class TriggerTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void variableAndParamInjection() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new Shell("env"));
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("MY_PARAM", "foo")));
+
+        CIBuildTrigger trigger = addCiBuildTrigger(p);
+
+        QueueTaskFuture<AbstractBuild> qtf = trigger.scheduleBuild(Collections.singletonMap("CI_MESSAGE", "message content"));
+
+        AbstractBuild build = j.assertBuildStatusSuccess(qtf);
+        j.assertLogContains("CI_MESSAGE=message content", build);
+        j.assertLogContains("MY_PARAM=foo", build);
+    }
+
+    @Test
+    public void ignoreMessageThatIsTooLong() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new Shell("env"));
+
+        CIBuildTrigger trigger = addCiBuildTrigger(p);
+
+        QueueTaskFuture<AbstractBuild> qtf = trigger.scheduleBuild(Collections.singletonMap("CI_MESSAGE", Strings.repeat("a", 131061)));
+        AbstractBuild build = j.assertBuildStatusSuccess(qtf);
+
+    }
+
+    private CIBuildTrigger addCiBuildTrigger(FreeStyleProject p) throws java.io.IOException {
+        CIBuildTrigger trigger = new CIBuildTrigger();
+        p.addTrigger(trigger);
+        trigger.start(p, true);
+        return trigger;
+    }
+}


### PR DESCRIPTION
When message grows too long (+128kb), it can cause build cannot launch OS processes because of that.

(Filing early to see the reproducer is working in public CI)