### PR TITLE
Fix: CI_MESSAGE has incorrect format

### DIFF
--- a/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
+++ b/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
@@ -177,7 +177,7 @@ public class RabbitMQMessagingWorker extends JMSMessagingWorker {
                     //
                     if (provider.verify(data.getBodyJson(), pd.getChecks(), jobname)) {
                         Map<String, String> params = new HashMap<String, String>();
-                        params.put("CI_MESSAGE", data.toJson());
+                        params.put("CI_MESSAGE", data.getBodyJson());
                         trigger(jobname, data.getBodyJson(), params);
                     }
                     channel.basicAck(data.getDeliveryTag(), false);


### PR DESCRIPTION
I noticed that there is difference between FedMsg implementation and RabbitMQ implementation and this is probably causing wrong format of CI_MESSAGE.

Fixes #165