### PR TITLE
Test downgrading Jenkins version

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -54,7 +54,7 @@
              than the parent version above
         -->
         <java.level>8</java.level>
-        <jenkins.version>2.176.1</jenkins.version>
+        <jenkins.version>2.150.2</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>


### PR DESCRIPTION
For now Jenkins version is 2.176.1, we want to downgrade Jenkins version as low as possible so we can let more users the ability to use the plugin.