### PR TITLE
Allow sending notification to queue when useQueues is true

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -371,8 +371,13 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                 connection.start();
 
                 session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                Destination destination = session.createTopic(ltopic);
-                publisher = session.createProducer(destination);
+                if (provider.getUseQueues()) {
+                    Queue destination = session.createQueue(ltopic);
+                    publisher = session.createProducer(destination);
+                } else {
+                    Destination destination = session.createTopic(ltopic);
+                    publisher = session.createProducer(destination);
+                }
 
                 message = session.createTextMessage("");
                 message.setJMSType(JSON_TYPE);


### PR DESCRIPTION
It is useful to be able to send message to queue or topic, depending on provider configuration. 

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>