### PR TITLE
Make ProjectChangeListener to be Pipeline friendly

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/ProjectChangeListener.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/ProjectChangeListener.java
@@ -3,7 +3,6 @@ package com.redhat.jenkins.plugins.ci;
 import hudson.Extension;
 import hudson.model.BuildableItem;
 import hudson.model.Item;
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.listeners.ItemListener;
 
@@ -46,8 +45,8 @@ public class ProjectChangeListener extends ItemListener {
         super.onUpdated(item);
         CIBuildTrigger cibt = CIBuildTrigger.findTrigger(item.getFullName());
         if (cibt != null) {
-            if (item instanceof AbstractProject) {
-                AbstractProject<?, ?> project = (AbstractProject<?, ?>) item;
+            if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {
+                ParameterizedJobMixIn.ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) item;
                 List<CITriggerThread> triggerThreads = CIBuildTrigger.locks.get(item.getFullName());
                 if (triggerThreads != null && triggerThreads.size() > 0) {
                     log.info("Getting trigger threads.");

--- a/ui-tests/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
+++ b/ui-tests/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
@@ -296,6 +296,12 @@ public class AmqMessagingPluginIntegrationTest extends SharedMessagingPluginInte
         _testDisabledJobDoesNotGetTriggeredWithCheck();
     }
 
+    @WithPlugins("workflow-aggregator")
+    @Test
+    public void testDisabledWorkflowJobDoesNotGetTriggered() throws Exception {
+        _testDisabledWorkflowJobDoesNotGetTriggered();
+    }
+
     @Test
     public void testEnsureFailedSendingOfMessageFailsBuild() throws Exception {
         stopContainer(amq);


### PR DESCRIPTION
Let's use ParameterizedJobMixIn.ParameterizedJob instead of
AbstractProject when handling onUpdated event. This will allow for
handling AbstractJob and WorkflowJob related updates.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>