### PR TITLE
RabbitMQ - request new queue when it's not created

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
@@ -67,8 +67,16 @@ public class RabbitMQMessagingWorker extends JMSMessagingWorker {
                     if (channel == null || !channel.isOpen()) {
                         this.channel = connection.createChannel();
                         log.info("Subscribing job '" + jobname + "' to " + this.topic + " topic.");
-                        channel.exchangeDeclarePassive(exchangeName);
                         String queueName = getQueue(provider);
+                        try {
+                            // Check if queue exists
+                            channel.queueDeclarePassive(queueName);
+                        } catch (IOException e) {
+                            // Request new queue - durable false, exclusive true, autodelete true
+                            this.channel = connection.createChannel();
+                            channel.queueDeclare(queueName, false, true, true, null);
+                        }
+                        channel.exchangeDeclarePassive(exchangeName);
                         channel.queueBind(queueName, exchangeName, this.topic);
 
                         // Create deliver callback to listen for messages


### PR DESCRIPTION
Adding check if queue is defined if it's not defined then new queue is
requested.

Fixes #200 