### PR TITLE
Enable setting of activemq.prefetchSize configuration variable

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
@@ -102,7 +102,7 @@ public final class GlobalCIConfiguration extends GlobalConfiguration {
                 if (getProvider(DEFAULT_PROVIDER) == null) {
                     log.info("There is no default Message Provider.");
                     configs.add(new ActiveMqMessagingProvider(DEFAULT_PROVIDER,
-                            broker, false, topic, new DefaultTopicProvider(), new UsernameAuthenticationMethod(user, password)));
+                            broker, false, topic, new DefaultTopicProvider(), new UsernameAuthenticationMethod(user, password), 0));
                     log.info("Added default Message Provider using deprecated configuration.");
                     setMigrationInProgress(true);
                 } else {

--- a/plugin/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider/config.jelly
+++ b/plugin/src/main/resources/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider/config.jelly
@@ -44,6 +44,9 @@
     <f:dropdownDescriptorSelector title="${%Authentication Method}"
                                   field="authenticationMethod"
                                   descriptors="${descriptor.getAuthenticationMethodDescriptors()}" />
+    <f:entry title="${%Prefetch size}" field="prefetchSize">
+      <f:textbox />
+    </f:entry>
   </f:section>
 </j:jelly>
 

--- a/plugin/src/test/resources/com/redhat/jenkins/plugins/ci/MigrationTest/testPrefetchSizeSetup/com.redhat.jenkins.plugins.ci.GlobalCIConfiguration.xml
+++ b/plugin/src/test/resources/com/redhat/jenkins/plugins/ci/MigrationTest/testPrefetchSizeSetup/com.redhat.jenkins.plugins.ci.GlobalCIConfiguration.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.redhat.jenkins.plugins.ci.GlobalCIConfiguration plugin="jms-messaging@1.0.5-SNAPSHOT">
+    <configs>
+        <com.redhat.jenkins.plugins.ci.messaging.ActiveMqMessagingProvider>
+            <name>default</name>
+            <broker>tcp://ci-bus.lab.eng.rdu2.redhat.com:61616</broker>
+            <topic>CI</topic>
+            <user>scott</user>
+            <password>SwplaNKdduIZ1jnUpKoiaWJd6Rw1IhgdvVBPy428I9I=</password>
+            <prefetchSize>0</prefetchSize>
+        </com.redhat.jenkins.plugins.ci.messaging.ActiveMqMessagingProvider>
+    </configs>
+</com.redhat.jenkins.plugins.ci.GlobalCIConfiguration>

--- a/plugin/src/test/resources/com/redhat/jenkins/plugins/ci/MigrationTest/testPrefetchSizeSetup/config.xml
+++ b/plugin/src/test/resources/com/redhat/jenkins/plugins/ci/MigrationTest/testPrefetchSizeSetup/config.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+    <disabledAdministrativeMonitors/>
+    <version>1.651.3</version>
+    <numExecutors>2</numExecutors>
+    <mode>NORMAL</mode>
+    <useSecurity>true</useSecurity>
+    <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+    <securityRealm class="hudson.security.SecurityRealm$None"/>
+    <disableRememberMe>false</disableRememberMe>
+    <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+    <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+    <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+    <jdks/>
+    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+    <clouds>
+    </clouds>
+    <quietPeriod>5</quietPeriod>
+    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+    <views>
+        <hudson.model.AllView>
+            <owner class="hudson" reference="../../.."/>
+            <name>All</name>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+    </views>
+    <primaryView>All</primaryView>
+    <slaveAgentPort>0</slaveAgentPort>
+    <label></label>
+    <nodeProperties/>
+    <globalNodeProperties/>
+</hudson>


### PR DESCRIPTION
Enables user to set prefetchSize. By leaving prefetchSize==0 we leave it up
to message broker.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
