### PR TITLE
Replace deprecated guava method

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -26,7 +26,6 @@ package com.redhat.jenkins.plugins.ci.messaging;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Objects;
 import com.redhat.jenkins.plugins.ci.CIEnvironmentContributingAction;
 import com.redhat.jenkins.plugins.ci.messaging.data.SendResult;
 import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQPublisherProviderData;
@@ -70,6 +69,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -243,10 +243,10 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                     root.set(field, mapper.convertValue(mm.getObject(field), JsonNode.class));
                 }
                 String value = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root);
-                return Objects.firstNonNull(value, "");
+                return Objects.requireNonNullElse(value, "");
             } else if (message instanceof TextMessage) {
                 TextMessage tm = (TextMessage) message;
-                return Objects.firstNonNull(tm.getText(), "");
+                return Objects.requireNonNullElse(tm.getText(), "");
             } else if (message instanceof BytesMessage) {
                 BytesMessage bm = (BytesMessage) message;
                 bm.reset();

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
@@ -23,7 +23,6 @@
  */
 package com.redhat.jenkins.plugins.ci.integration;
 
-import com.google.common.base.Objects;
 import com.redhat.jenkins.plugins.ci.CIBuildTrigger;
 import com.redhat.jenkins.plugins.ci.CIMessageBuilder;
 import com.redhat.jenkins.plugins.ci.GlobalCIConfiguration;
@@ -53,6 +52,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import java.util.Objects;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -98,7 +98,7 @@ public class AmqMessagingPluginIntegrationTest extends SharedMessagingPluginInte
                 overrideTopic(topic),
                 Util.fixNull(selector),
                 Arrays.asList(msgChecks),
-                Objects.firstNonNull(variableName, "CI_MESSAGE"),
+                Objects.requireNonNullElse(variableName, "CI_MESSAGE"),
                 60
         );
     }

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/RabbitMQMessagingPluginIntegrationTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/RabbitMQMessagingPluginIntegrationTest.java
@@ -23,7 +23,6 @@
  */
 package com.redhat.jenkins.plugins.ci.integration;
 
-import com.google.common.base.Objects;
 import com.redhat.jenkins.plugins.ci.CIMessageNotifier;
 import com.redhat.jenkins.plugins.ci.GlobalCIConfiguration;
 import com.redhat.jenkins.plugins.ci.authentication.rabbitmq.UsernameAuthenticationMethod;
@@ -45,6 +44,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import java.util.Objects;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -75,7 +75,7 @@ public class RabbitMQMessagingPluginIntegrationTest extends SharedMessagingPlugi
                 DEFAULT_PROVIDER_NAME,
                 overrideTopic(topic),
                 Arrays.asList(msgChecks),
-                Objects.firstNonNull(variableName, "CI_MESSAGE"),
+                Objects.requireNonNullElse(variableName, "CI_MESSAGE"),
                 60
         );
     }


### PR DESCRIPTION
* Since Jenkins 2.320 new version of Guava is used
  - https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
* method com.google.common.base.Objects.firstNonNull(T, T) is deprecated
  - https://guava.dev/releases/19.0/api/docs/deprecated-list.html

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
