### PR TITLE
Avoid guava incompatibility

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -44,7 +44,7 @@
 
     <properties>
         <java.level>8</java.level>
-        <jenkins.version>2.277.3</jenkins.version>
+        <jenkins.version>2.303</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <spotbugs.failOnError>false</spotbugs.failOnError>
     </properties>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -102,22 +102,22 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
 
         <dependency>

--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -26,8 +26,6 @@ package com.redhat.jenkins.plugins.ci.messaging;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Objects;
-import com.google.common.base.MoreObjects;
 import com.redhat.jenkins.plugins.ci.CIEnvironmentContributingAction;
 import com.redhat.jenkins.plugins.ci.messaging.data.SendResult;
 import com.redhat.jenkins.plugins.ci.provider.data.ActiveMQPublisherProviderData;
@@ -36,6 +34,7 @@ import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
 import com.redhat.utils.OrderedProperties;
 import com.redhat.utils.PluginUtils;
 import hudson.EnvVars;
+import hudson.Util;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -244,10 +243,10 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                     root.set(field, mapper.convertValue(mm.getObject(field), JsonNode.class));
                 }
                 String value = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root);
-                return MoreObjects.firstNonNull(value, "");
+                return Util.fixNull(value);
             } else if (message instanceof TextMessage) {
                 TextMessage tm = (TextMessage) message;
-                return MoreObjects.firstNonNull(tm.getText(), "");
+                return Util.fixNull(tm.getText());
             } else if (message instanceof BytesMessage) {
                 BytesMessage bm = (BytesMessage) message;
                 bm.reset();

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/AmqMessagingPluginIntegrationTest.java
@@ -23,8 +23,6 @@
  */
 package com.redhat.jenkins.plugins.ci.integration;
 
-import com.google.common.base.Objects;
-import com.google.common.base.MoreObjects;
 import com.redhat.jenkins.plugins.ci.CIBuildTrigger;
 import com.redhat.jenkins.plugins.ci.CIMessageBuilder;
 import com.redhat.jenkins.plugins.ci.GlobalCIConfiguration;
@@ -99,7 +97,7 @@ public class AmqMessagingPluginIntegrationTest extends SharedMessagingPluginInte
                 overrideTopic(topic),
                 Util.fixNull(selector),
                 Arrays.asList(msgChecks),
-                MoreObjects.firstNonNull(variableName, "CI_MESSAGE"),
+                Util.fixNull(variableName, "CI_MESSAGE"),
                 60
         );
     }

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/RabbitMQMessagingPluginIntegrationTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/integration/RabbitMQMessagingPluginIntegrationTest.java
@@ -23,8 +23,6 @@
  */
 package com.redhat.jenkins.plugins.ci.integration;
 
-import com.google.common.base.Objects;
-import com.google.common.base.MoreObjects;
 import com.redhat.jenkins.plugins.ci.CIMessageNotifier;
 import com.redhat.jenkins.plugins.ci.GlobalCIConfiguration;
 import com.redhat.jenkins.plugins.ci.authentication.rabbitmq.UsernameAuthenticationMethod;
@@ -35,6 +33,7 @@ import com.redhat.jenkins.plugins.ci.provider.data.ProviderData;
 import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQPublisherProviderData;
 import com.redhat.jenkins.plugins.ci.provider.data.RabbitMQSubscriberProviderData;
 import com.redhat.utils.MessageUtils;
+import hudson.Util;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.util.Secret;
@@ -76,7 +75,7 @@ public class RabbitMQMessagingPluginIntegrationTest extends SharedMessagingPlugi
                 DEFAULT_PROVIDER_NAME,
                 overrideTopic(topic),
                 Arrays.asList(msgChecks),
-                MoreObjects.firstNonNull(variableName, "CI_MESSAGE"),
+                Util.fixNull(variableName, "CI_MESSAGE"),
                 60
         );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.1.27-SNAPSHOT</version>
 
     <properties>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.303</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Alternative of https://github.com/jenkinsci/jms-messaging-plugin/pull/233 that is getting rid of guava for the tasks altogether.