### PR TITLE
Save configuration after adding new provider

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/GlobalCIConfiguration.java
@@ -139,7 +139,9 @@ public final class GlobalCIConfiguration extends GlobalConfiguration {
         if (configs.contains(provider)) {
             throw new Failure("Attempt to add a duplicate message provider");
         }
+        log.info("Add message provider " + provider.getName());
         configs.add(provider);
+        save();
         return true;
     }
 

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/AddMessageProviderTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/AddMessageProviderTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.redhat.jenkins.plugins.ci;
+
+import com.redhat.jenkins.plugins.ci.authentication.activemq.SSLCertificateAuthenticationMethod;
+import com.redhat.jenkins.plugins.ci.messaging.ActiveMqMessagingProvider;
+import com.redhat.jenkins.plugins.ci.messaging.topics.UMBTopicProvider;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author ogondza.
+ */
+public class AddMessageProviderTest {
+    @Rule public final JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void addMessageProvider(){
+        ActiveMqMessagingProvider provider = new ActiveMqMessagingProvider(
+                "UMB",
+                "ssh://umb.api.redhat.com:61616",
+                false,
+                "VirtualTopic.eng.cd.rh-sso.&gt;",
+                new UMBTopicProvider(),
+                new SSLCertificateAuthenticationMethod(
+                        "/ver/run/secrets/casc-secret/rhssocdjenkins.jks",
+                        Secret.fromString("secret1"),
+                        "/var/run/secrets/casc-secret/rh-it-trust.jks",
+                        Secret.fromString("secret2")
+                        )
+        );
+        GlobalCIConfiguration gc  = GlobalCIConfiguration.get();
+        gc.addMessageProvider(provider);
+        assertEquals(gc.getProvider("UMB"), provider);
+        GlobalCIConfiguration gc2 = new GlobalCIConfiguration();
+        assertEquals(gc.getConfigs(), gc2.getConfigs());
+
+    }
+}


### PR DESCRIPTION
Related Jira ticket - [CPAAS-5012](https://issues.redhat.com/browse/CPAAS-5012)
The GlobalConfiguration is resaved when a new provider is added.
This solves an existing bug: when jenkins restart, it doesn't found the previously added providers and this cause job triggers listeners to stop working.

### Testing done

Added the new testcase `AddMessageProviderTest` that checks:
- The added provided is included in the GlobalCIConfiguration
- The added provided keeps there even if a new GlobalCIConfiguration is loaded from configuration file.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


