### PR TITLE
Update hamcrest

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -319,13 +319,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
_🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

  All deprecated modules' code has been merged into 'hamcrest'.
  Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

  Ping `@NotMyFault` if you have questions.

  _[script source](https://github.com/NotMyFault/jenkins-version-updater)_

Edit: The same build failures are present on the master branch.