### PR TITLE
README.md: provide example RabbitMQ config for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ unclassified:
               trustpwd: "trustpwd" # User, encrypt secrets
 ```
 
+A more realistic example is the RabbitMQ configuration for Fedora's broker,
+connecting to the public endpoint:
+
+```
+unclassified:
+  jmsProviders:
+    configs:
+    - rabbitMq:
+        exchange: "amq.topic"
+        hostname: "rabbitmq.fedoraproject.org"
+        name: "Fedora Messaging"
+        portNumber: 5671
+        virtualHost: "/public_pubsub"
+        authenticationMethod:
+          sslCertificate:
+            username: "fedora"
+            keystore: "/path/to/keystore.jks"
+            keypwd: "sooperseekret"
+            truststore: "/path/to/truststore.jks"
+            trustpwd: "sooperseekret"
+```
+
+For a tutorial on how to create keystores from the certificates and private key
+in the `fedora-messaging` RPM package, see
+[this guide](https://docs.oracle.com/cd/E35976_01/server.740/es_admin/src/tadm_ssl_convert_pem_to_jks.html).
+
 ## Triggering
 
 To enable the CI trigger, go to the job configuration page and add click


### PR DESCRIPTION
Make it easier for people using this plugin to connect to Fedora's broker by providing a snippet of the required configuration. This would've saved me a lot of time.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

This JCasC snippet is lightly adapted from the JCasC plugin itself on a working Jenkins instance (via the tool to view the current configuration in `$JENKINS_URL/manage/configuration-as-code/`).

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (N/A)
- [x] Link to relevant pull requests, esp. upstream and downstream changes (N/A)
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
