### PR TITLE
Remove duplicate jenkins.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
     <version>1.1.29-SNAPSHOT</version>
 
     <properties>
-        <jenkins.version>2.346.3</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Remove duplicate `jenkins.version` property from the parent pom as it is already defined in the plugin module.

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

