### PR TITLE
Fix to remove recursing between formatMessage and getMessageBody.

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -234,7 +234,8 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
 
             return mapper.writer().writeValueAsString(root);
         } catch (JMSException | JsonProcessingException e) {
-            log.log(Level.SEVERE, "Unhandled exception retrieving message headers:\n" + formatMessage(message), e);
+            log.log(Level.SEVERE, "Unhandled exception retrieving message headers:\n" + formatMessage(message, false),
+                    e);
         }
 
         return "";
@@ -265,10 +266,10 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                 bm.readBytes(bytes);
                 return new String(bytes, StandardCharsets.UTF_8);
             } else {
-                log.log(Level.SEVERE, "Unsupported message type:\n" + formatMessage(message));
+                log.log(Level.SEVERE, "Unsupported message type:\n" + formatMessage(message, false));
             }
         } catch (Exception e) {
-            log.log(Level.SEVERE, "Unhandled exception retrieving message body:\n" + formatMessage(message), e);
+            log.log(Level.SEVERE, "Unhandled exception retrieving message body:\n" + formatMessage(message, false), e);
         }
 
         return "";
@@ -290,7 +291,7 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
             }
             super.trigger(jobname, formatMessage(message), params);
         } catch (Exception e) {
-            log.log(Level.SEVERE, "Unhandled exception processing message:\n" + formatMessage(message), e);
+            log.log(Level.SEVERE, "Unhandled exception processing message:\n" + formatMessage(message, false), e);
         }
     }
 
@@ -712,15 +713,20 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
     }
 
     public static String formatMessage(Message message) {
-        StringBuilder sb = new StringBuilder();
+        return formatMessage(message, true);
+    }
 
+    public static String formatMessage(Message message, boolean includeBody) {
+        StringBuilder sb = new StringBuilder();
         try {
+            sb.append("Message class: ");
+            sb.append(message.getClass().getName());
+            sb.append("\n");
             String headers = formatHeaders(message);
             if (headers.length() > 0) {
                 sb.append("Message Headers:\n");
                 sb.append(headers);
             }
-
             sb.append("Message Properties:\n");
             @SuppressWarnings("unchecked")
             Enumeration<String> propNames = message.getPropertyNames();
@@ -729,18 +735,19 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                 sb.append("  ");
                 sb.append(propertyName);
                 sb.append(": ");
-                if (message.getObjectProperty(propertyName) != null) {
-                    sb.append(message.getObjectProperty(propertyName).toString());
+                try {
+                    if (message.getObjectProperty(propertyName) != null) {
+                        sb.append(message.getObjectProperty(propertyName).toString());
+                    }
+                } catch (JMSException e) {
+                    sb.append("(unable to read)");
                 }
                 sb.append("\n");
             }
-
-            sb.append("Message Body:\n");
-            sb.append(getMessageBody(message));
+            sb.append(includeBody ? "Message Body:\n" + getMessageBody(message) : "Message Body: <omitted>\n");
         } catch (Exception e) {
             log.log(Level.SEVERE, "Unable to format message:", e);
         }
-
         return sb.toString();
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix to remove recursing between formatMessage and getMessageBody.

Resolves #358.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
