### PR TITLE
Fix getMessageHeaders() crash on JMSReplyTo with ActiveMQTopic

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -228,7 +228,8 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
             root.set("JMSMessageID", mapper.convertValue(message.getJMSMessageID(), JsonNode.class));
             root.set("JMSPriority", mapper.convertValue(message.getJMSPriority(), JsonNode.class));
             root.set("JMSRedelivered", mapper.convertValue(message.getJMSRedelivered(), JsonNode.class));
-            root.set("JMSReplyTo", mapper.convertValue(message.getJMSReplyTo(), JsonNode.class));
+            Destination replyTo = message.getJMSReplyTo();
+            root.set("JMSReplyTo", mapper.convertValue(replyTo != null ? replyTo.toString() : null, JsonNode.class));
             root.set("JMSTimestamp", mapper.convertValue(message.getJMSTimestamp(), JsonNode.class));
             root.set("JMSType", mapper.convertValue(message.getJMSType(), JsonNode.class));
 

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
@@ -1,0 +1,51 @@
+package com.redhat.jenkins.plugins.ci.messaging;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.apache.activemq.command.ActiveMQTopic;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.jms.Message;
+
+public class ActiveMqMessagingWorkerTest {
+
+    @Test
+    public void getMessageHeadersHandlesJMSReplyToWithActiveMQTopic() throws Exception {
+        Message message = mock(Message.class);
+        ActiveMQTopic replyTopic = new ActiveMQTopic("VirtualTopic.some.reply.topic");
+        when(message.getJMSReplyTo()).thenReturn(replyTopic);
+        when(message.getJMSDestination()).thenReturn(new ActiveMQTopic("VirtualTopic.test"));
+        when(message.getPropertyNames()).thenReturn(Collections.emptyEnumeration());
+
+        String headers = ActiveMqMessagingWorker.getMessageHeaders(message);
+
+        assertFalse("Headers should not be empty", headers.isEmpty());
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(headers);
+        assertThat(root.get("JMSReplyTo").asText(), containsString("VirtualTopic.some.reply.topic"));
+    }
+
+    @Test
+    public void getMessageHeadersHandlesNullJMSReplyTo() throws Exception {
+        Message message = mock(Message.class);
+        when(message.getJMSReplyTo()).thenReturn(null);
+        when(message.getJMSDestination()).thenReturn(new ActiveMQTopic("VirtualTopic.test"));
+        when(message.getPropertyNames()).thenReturn(Collections.emptyEnumeration());
+
+        String headers = ActiveMqMessagingWorker.getMessageHeaders(message);
+
+        assertFalse("Headers should not be empty", headers.isEmpty());
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(headers);
+        assertThat("JMSReplyTo should be null node", root.get("JMSReplyTo").isNull(), org.hamcrest.Matchers.is(true));
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `InvalidDefinitionException` in `ActiveMqMessagingWorker.getMessageHeaders()` when a message has `JMSReplyTo` set to an ActiveMQ destination
- Convert `JMSReplyTo` `Destination` to its string representation before Jackson serialization, matching the existing pattern used for `JMSDestination`
- Add unit tests for `getMessageHeaders()` covering both non-null and null `JMSReplyTo`

Fixes #375

## Test plan

- [x] New unit test: `ActiveMqMessagingWorkerTest#getMessageHeadersHandlesJMSReplyToWithActiveMQTopic` — verifies headers are correctly serialized when `JMSReplyTo` is an `ActiveMQTopic`
- [x] New unit test: `ActiveMqMessagingWorkerTest#getMessageHeadersHandlesNullJMSReplyTo` — verifies headers work when `JMSReplyTo` is null
- [x] `mvn -pl plugin test -Dtest=ActiveMqMessagingWorkerTest` passes

🤖 Generated with [Claude Code](https://claude.ai/code)