### PR TITLE
Fix getMessageHeaders() crash on JMSReplyTo and null-safety for JMSDestination

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -223,12 +223,15 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
 
             root.set("JMSCorrelationID", mapper.convertValue(message.getJMSCorrelationID(), JsonNode.class));
             root.set("JMSDeliveryMode", mapper.convertValue(message.getJMSDeliveryMode(), JsonNode.class));
-            root.set("JMSDestination", mapper.convertValue(message.getJMSDestination().toString(), JsonNode.class));
+            Destination destination = message.getJMSDestination();
+            root.set("JMSDestination",
+                    mapper.convertValue(destination != null ? destination.toString() : null, JsonNode.class));
             root.set("JMSExpiration", mapper.convertValue(message.getJMSExpiration(), JsonNode.class));
             root.set("JMSMessageID", mapper.convertValue(message.getJMSMessageID(), JsonNode.class));
             root.set("JMSPriority", mapper.convertValue(message.getJMSPriority(), JsonNode.class));
             root.set("JMSRedelivered", mapper.convertValue(message.getJMSRedelivered(), JsonNode.class));
-            root.set("JMSReplyTo", mapper.convertValue(message.getJMSReplyTo(), JsonNode.class));
+            Destination replyTo = message.getJMSReplyTo();
+            root.set("JMSReplyTo", mapper.convertValue(replyTo != null ? replyTo.toString() : null, JsonNode.class));
             root.set("JMSTimestamp", mapper.convertValue(message.getJMSTimestamp(), JsonNode.class));
             root.set("JMSType", mapper.convertValue(message.getJMSType(), JsonNode.class));
 

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
@@ -1,0 +1,74 @@
+package com.redhat.jenkins.plugins.ci.messaging;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.apache.activemq.command.ActiveMQTopic;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.jms.Message;
+
+public class ActiveMqMessagingWorkerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private Message newStubMessage() throws Exception {
+        Message message = mock(Message.class);
+        when(message.getPropertyNames()).thenReturn(Collections.emptyEnumeration());
+        return message;
+    }
+
+    @Test
+    public void getMessageHeaders_jmsReplyToWithActiveMQTopic() throws Exception {
+        Message message = newStubMessage();
+        ActiveMQTopic replyTopic = new ActiveMQTopic("VirtualTopic.some.reply.topic");
+        when(message.getJMSReplyTo()).thenReturn(replyTopic);
+        when(message.getJMSDestination()).thenReturn(new ActiveMQTopic("VirtualTopic.test"));
+
+        String headers = ActiveMqMessagingWorker.getMessageHeaders(message);
+        JsonNode root = mapper.readTree(headers);
+
+        assertThat(root.get("JMSReplyTo").asText(), is("topic://VirtualTopic.some.reply.topic"));
+    }
+
+    @Test
+    public void getMessageHeaders_nullJMSReplyTo() throws Exception {
+        Message message = newStubMessage();
+        when(message.getJMSReplyTo()).thenReturn(null);
+        when(message.getJMSDestination()).thenReturn(new ActiveMQTopic("VirtualTopic.test"));
+
+        String headers = ActiveMqMessagingWorker.getMessageHeaders(message);
+        JsonNode root = mapper.readTree(headers);
+
+        assertThat(root.get("JMSReplyTo").isNull(), is(true));
+    }
+
+    @Test
+    public void getMessageHeaders_nullJMSDestination() throws Exception {
+        Message message = newStubMessage();
+        when(message.getJMSDestination()).thenReturn(null);
+
+        String headers = ActiveMqMessagingWorker.getMessageHeaders(message);
+        JsonNode root = mapper.readTree(headers);
+
+        assertThat(root.get("JMSDestination").isNull(), is(true));
+    }
+
+    @Test
+    public void getMessageHeaders_jmsDestinationWithActiveMQTopic() throws Exception {
+        Message message = newStubMessage();
+        when(message.getJMSDestination()).thenReturn(new ActiveMQTopic("VirtualTopic.test"));
+
+        String headers = ActiveMqMessagingWorker.getMessageHeaders(message);
+        JsonNode root = mapper.readTree(headers);
+
+        assertThat(root.get("JMSDestination").asText(), is("topic://VirtualTopic.test"));
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `InvalidDefinitionException` in `ActiveMqMessagingWorker.getMessageHeaders()` when a message has `JMSReplyTo` set to an ActiveMQ destination — converts the `Destination` to its string representation before Jackson serialization, matching the existing pattern used for `JMSDestination`
- Fix latent `NullPointerException` in the same method where `JMSDestination` called `.toString()` without a null check
- Add unit tests for `getMessageHeaders()` covering both `JMSReplyTo` and `JMSDestination` with non-null and null values

Fixes #375
Supersedes #376

## Test plan

- [x] `getMessageHeaders_jmsReplyToWithActiveMQTopic` — verifies headers serialize correctly when `JMSReplyTo` is an `ActiveMQTopic`
- [x] `getMessageHeaders_nullJMSReplyTo` — verifies null `JMSReplyTo` produces a JSON null node
- [x] `getMessageHeaders_nullJMSDestination` — verifies null `JMSDestination` is handled safely (pre-existing latent bug)
- [x] `getMessageHeaders_jmsDestinationWithActiveMQTopic` — verifies `JMSDestination` string serialization still works
- [x] `mvn -pl plugin test -Dtest=ActiveMqMessagingWorkerTest` passes

🤖 Generated with [Claude Code](https://claude.ai/code)