### PR TITLE
Fix NPE race condition in CIBuildTrigger.stopTriggerThreads()

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
@@ -240,8 +240,8 @@ public class CIBuildTrigger extends Trigger<Job<?, ?>> {
     }
 
     private List<CITriggerThread> stopTriggerThreads(String fullName, List<CITriggerThread> comparisonThreads) {
-        synchronized (locks.computeIfAbsent(fullName, o -> new ArrayList<>())) {
-            List<CITriggerThread> threads = locks.get(fullName);
+        List<CITriggerThread> threads = locks.computeIfAbsent(fullName, o -> new ArrayList<>());
+        synchronized (threads) {
             // If threads are the same we have start/stop sequence, so don't bother stopping.
             if (comparisonThreads != null && threads.size() == comparisonThreads.size()) {
                 for (CITriggerThread thread : threads) {


### PR DESCRIPTION
## Summary

- Fix `NullPointerException` in `CIBuildTrigger.stopTriggerThreads()` caused by a race condition between concurrent callers
- Regression from 60248ea (#368) which added `locks.remove(fullName)` without fixing the `synchronized(locks.computeIfAbsent(...))` + `locks.get()` pattern — when two threads call `stopTriggerThreads` concurrently for the same job, the second thread's `locks.get()` returns `null` after the first thread removes the entry
- Apply the same fix already used in `startTriggerThreads()`: capture the list from `computeIfAbsent` into a local variable and synchronize on it directly

This is the bug that has been failing `KafkaMessagingPluginIntegrationTest.testPipelineJobProperties` on CI since the 2.0.3 release, blocking all PRs including dependabot updates.

## Test plan

- [x] `KafkaMessagingPluginIntegrationTest#testPipelineJobProperties` — was failing 100% before, now passes
- [x] `ActiveMqMessagingWorkerTest` — unit tests still pass

🤖 Generated with [Claude Code](https://claude.ai/code)