### PR TITLE
Fix race between concurrent stop() and start() in CIBuildTrigger

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/CIBuildTrigger.java
@@ -210,8 +210,6 @@ public class CIBuildTrigger extends Trigger<Job<?, ?>> {
             List<CITriggerThread> threads = locks.computeIfAbsent(fullName, o -> new ArrayList<>());
             synchronized (threads) {
                 if (stopTriggerThreads(fullName) == null && providers != null) {
-                    // Re-add the threads list to the map after stopTriggerThreads removed it
-                    locks.put(fullName, threads);
                     int instance = 1;
                     for (ProviderData pd : providers) {
                         JMSMessagingProvider provider = GlobalCIConfiguration.get().getProvider(pd.getName());
@@ -270,8 +268,6 @@ public class CIBuildTrigger extends Trigger<Job<?, ?>> {
             }
 
             threads.clear();
-            locks.remove(fullName);
-            log.fine("Removed thread lock for '" + fullName + "'.");
         }
         return null;
     }


### PR DESCRIPTION
## Summary

Follow-up to #379. That fix addressed the NPE from `locks.get()` returning null, but a second race condition remained:

`startTriggerThreads()` calls `stopTriggerThreads()` internally while holding `synchronized(L1)`. The nested call does `locks.remove(fullName)`, temporarily removing L1 from the map. A concurrent `stop()` call during this window creates a **new** list L2 via `computeIfAbsent` and synchronizes on L2 instead of L1 — so it runs without contention and silently fails to stop anything. This causes trigger threads to leak, which is what the Kafka `testPipelineJobProperties` test detects via thread-count assertions.

**Fix:** stop removing entries from the `locks` map entirely. Just clear the list. This guarantees all callers for the same job always synchronize on the same object. The `locks.put()` re-add in `startTriggerThreads` is also removed since it's no longer needed. An empty `ArrayList` per job name is negligible memory compared to the thread safety guarantee.

## Test plan

- [x] `KafkaMessagingPluginIntegrationTest#testPipelineJobProperties` — the test that has been failing on CI
- [x] `ActiveMqMessagingWorkerTest` — unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)