### PR TITLE
Fix ActiveMQ listener threads hanging forever on stale connections

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -93,10 +93,30 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
     private MessageConsumer subscriber;
     private final String uuid = UUID.randomUUID().toString();
 
+    /*
+     * Bounds how long a single synchronous JMS request (e.g. setClientID(), which is invoked while establishing every
+     * connection) is allowed to block on a response from the broker. Without this, a connection that looks healthy at
+     * the TCP level but has gone silently stale (dropped by a NAT/firewall/load-balancer without a clean FIN/RST, or a
+     * broker that accepted the socket but never replies) causes the calling thread to park forever inside
+     * ActiveMQConnection#syncSendPacket, permanently killing the listener with no exception, no log line, and no retry.
+     */
+    private static final int JMS_SEND_TIMEOUT_MS = 60_000;
+
     public ActiveMqMessagingWorker(JMSMessagingProvider messagingProvider, MessagingProviderOverrides overrides,
             String jobname) {
         super(messagingProvider, overrides, jobname);
         this.provider = (ActiveMqMessagingProvider) messagingProvider;
+    }
+
+    /**
+     * Applies shared safety settings to a connection factory obtained from the provider. Returns {@code null} unchanged
+     * so callers can keep using a single null-check instead of duplicating configuration logic.
+     */
+    private static ActiveMQConnectionFactory configureConnectionFactory(ActiveMQConnectionFactory connectionFactory) {
+        if (connectionFactory != null) {
+            connectionFactory.setSendTimeout(JMS_SEND_TIMEOUT_MS);
+        }
+        return connectionFactory;
     }
 
     @Override
@@ -129,15 +149,23 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                 } catch (JMSSecurityException | InvalidSelectorException exc) {
                     log.log(Level.SEVERE, "JMS exception raised while subscribing job '" + jobname + "'.", exc);
                     throw new RuntimeException(exc);
-                } catch (JMSException ex) {
+                } catch (JMSException | RuntimeException ex) {
 
                     // Either we were interrupted, or something else went
                     // wrong. If we were interrupted, then we will jump ship
                     // on the next iteration. If something else happened,
                     // then we just unsubscribe here, sleep, so that we may
                     // try again on the next iteration.
+                    //
+                    // RuntimeException is caught here too (in addition to
+                    // JMSException) so that unexpected failures - e.g. a
+                    // provider whose credentials/SSL context are not yet
+                    // available, which previously surfaced as an uncaught
+                    // NullPointerException from connect() - retry like any
+                    // other connection failure instead of permanently
+                    // killing this thread.
 
-                    log.log(Level.SEVERE, "JMS exception raised while subscribing job '" + jobname + "', retrying in "
+                    log.log(Level.SEVERE, "Exception raised while subscribing job '" + jobname + "', retrying in "
                             + RETRY_MINUTES + " minutes.", ex);
                     if (!Thread.currentThread().isInterrupted()) {
 
@@ -165,7 +193,12 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
     @Override
     public boolean connect() {
         connection = null;
-        ActiveMQConnectionFactory connectionFactory = provider.getConnectionFactory();
+        ActiveMQConnectionFactory connectionFactory = configureConnectionFactory(provider.getConnectionFactory());
+        if (connectionFactory == null) {
+            log.severe("Unable to create connection factory for " + provider.getBroker()
+                    + ". Check the provider's authentication configuration (credentials may not be available yet).");
+            return false;
+        }
 
         Connection connectiontmp = null;
         try {
@@ -385,7 +418,13 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
         try {
             String ltopic = PluginUtils.getSubstitutedValue(getTopic(provider), run.getEnvironment(listener));
             if (provider.getAuthenticationMethod() != null && ltopic != null && provider.getBroker() != null) {
-                ActiveMQConnectionFactory connectionFactory = provider.getConnectionFactory();
+                ActiveMQConnectionFactory connectionFactory = configureConnectionFactory(
+                        provider.getConnectionFactory());
+                if (connectionFactory == null) {
+                    log.severe("Unable to create connection factory for " + provider.getBroker()
+                            + ". Check the provider's authentication configuration.");
+                    return new SendResult(false, mesgId, mesgContent);
+                }
                 connection = connectionFactory.createConnection();
                 connection.start();
 
@@ -518,7 +557,13 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
             Connection connection = null;
             MessageConsumer consumer = null;
             try {
-                ActiveMQConnectionFactory connectionFactory = provider.getConnectionFactory();
+                ActiveMQConnectionFactory connectionFactory = configureConnectionFactory(
+                        provider.getConnectionFactory());
+                if (connectionFactory == null) {
+                    log.severe("Unable to create connection factory for " + provider.getBroker()
+                            + ". Check the provider's authentication configuration.");
+                    return null;
+                }
                 connection = connectionFactory.createConnection();
                 connection.setClientID(ip + "_" + UUID.randomUUID());
                 connection.start();

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
@@ -3,16 +3,19 @@ package com.redhat.jenkins.plugins.ci.messaging;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
+import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 
 public class ActiveMqMessagingWorkerTest {
@@ -23,6 +26,45 @@ public class ActiveMqMessagingWorkerTest {
         Message message = mock(Message.class);
         when(message.getPropertyNames()).thenReturn(Collections.emptyEnumeration());
         return message;
+    }
+
+    private ActiveMqMessagingProvider newStubProvider() {
+        ActiveMqMessagingProvider provider = mock(ActiveMqMessagingProvider.class);
+        when(provider.getBroker()).thenReturn("failover:(ssl://broker1:61616,ssl://broker2:61616)");
+        when(provider.getName()).thenReturn("test-provider");
+        return provider;
+    }
+
+    @Test
+    public void connect_returnsFalseWhenConnectionFactoryIsNull() throws Exception {
+        // Simulates the boot-time race where credentials/SSL context are not
+        // yet available: getConnectionFactory() returns null instead of
+        // throwing. connect() must fail gracefully (so subscribe()'s retry
+        // loop can try again) rather than letting a NullPointerException
+        // escape and permanently kill the listener thread.
+        ActiveMqMessagingProvider provider = newStubProvider();
+        when(provider.getConnectionFactory()).thenReturn(null);
+
+        ActiveMqMessagingWorker worker = new ActiveMqMessagingWorker(provider, null, "some-job");
+
+        assertThat(worker.connect(), is(false));
+    }
+
+    @Test
+    public void connect_appliesBoundedSendTimeoutToConnectionFactory() throws Exception {
+        // Guards against a regression of the "hangs forever in
+        // setClientID()" issue: every connection factory handed to
+        // ActiveMQConnection must have a bounded send timeout so a stale
+        // broker connection fails fast instead of blocking indefinitely.
+        ActiveMqMessagingProvider provider = newStubProvider();
+        ActiveMQConnectionFactory connectionFactory = mock(ActiveMQConnectionFactory.class);
+        when(provider.getConnectionFactory()).thenReturn(connectionFactory);
+        when(connectionFactory.createConnection()).thenThrow(new JMSException("simulated broker failure"));
+
+        ActiveMqMessagingWorker worker = new ActiveMqMessagingWorker(provider, null, "some-job");
+
+        assertThat(worker.connect(), is(false));
+        verify(connectionFactory).setSendTimeout(60_000);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jms-messaging-plugin/issues/381 — see the issue for the full investigation and log evidence.

This PR makes ActiveMqMessagingWorker's connection handling fail fast and recover automatically instead of silently hanging or dying permanently:

* Add a bounded send timeout. `ActiveMQConnectionFactory#setSendTimeout(60_000)` is now applied everywhere a connection factory is obtained (`connect(), sendMessage(), waitForMessage()`) via a shared `configureConnectionFactory()` helper. Previously, synchronous JMS requests like `setClientID()` had no timeout and could block a listener thread indefinitely if the connection had gone stale without the client being notified.
* Guard against a null connection factory. `provider.getConnectionFactory()` can return null (e.g. credentials not yet loaded at Jenkins boot). All three call sites now check for null and fail into the existing retry/error path instead of throwing an uncaught `NullPointerException`.
* Broaden `subscribe()`'s retry to catch RuntimeException in addition to JMSException, so an unexpected runtime failure (such as the NPE above) triggers the same unsubscribe-and-retry-in-1-minute behavior instead of permanently killing the CITriggerThread.

**Tests**
Added two unit tests in `ActiveMqMessagingWorkerTest`:

* `connect_returnsFalseWhenConnectionFactoryIsNull` — verifies `connect()` fails gracefully instead of NPE-ing when the factory is null.
* `connect_appliesBoundedSendTimeoutToConnectionFactory` — verifies `setSendTimeout(60_000)` is applied to every connection factory before use.

Co-authored with Claude + Sonnet 5.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
