### PR TITLE
Set connection timeouts on ActiveMQ factory to prevent indefinite hangs

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingProvider.java
@@ -48,6 +48,9 @@ public class ActiveMqMessagingProvider extends JMSMessagingProvider {
 
     private static final long serialVersionUID = -5710867670450057616L;
 
+    static final int CONNECT_RESPONSE_TIMEOUT_MS = 60_000;
+    static final int SEND_TIMEOUT_MS = 60_000;
+
     private String broker;
     private Boolean useQueues;
     private transient boolean migrationInProgress = false;
@@ -133,7 +136,12 @@ public class ActiveMqMessagingProvider extends JMSMessagingProvider {
 
     public ActiveMQConnectionFactory getConnectionFactory(String broker,
             ActiveMQAuthenticationMethod authenticationMethod) {
-        return authenticationMethod.getConnectionFactory(broker);
+        ActiveMQConnectionFactory factory = authenticationMethod.getConnectionFactory(broker);
+        if (factory != null) {
+            factory.setConnectResponseTimeout(CONNECT_RESPONSE_TIMEOUT_MS);
+            factory.setSendTimeout(SEND_TIMEOUT_MS);
+        }
+        return factory;
     }
 
     @Override

--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -129,7 +129,7 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                 } catch (JMSSecurityException | InvalidSelectorException exc) {
                     log.log(Level.SEVERE, "JMS exception raised while subscribing job '" + jobname + "'.", exc);
                     throw new RuntimeException(exc);
-                } catch (JMSException ex) {
+                } catch (JMSException | RuntimeException ex) {
 
                     // Either we were interrupted, or something else went
                     // wrong. If we were interrupted, then we will jump ship
@@ -137,7 +137,7 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
                     // then we just unsubscribe here, sleep, so that we may
                     // try again on the next iteration.
 
-                    log.log(Level.SEVERE, "JMS exception raised while subscribing job '" + jobname + "', retrying in "
+                    log.log(Level.SEVERE, "Exception raised while subscribing job '" + jobname + "', retrying in "
                             + RETRY_MINUTES + " minutes.", ex);
                     if (!Thread.currentThread().isInterrupted()) {
 
@@ -166,6 +166,10 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
     public boolean connect() {
         connection = null;
         ActiveMQConnectionFactory connectionFactory = provider.getConnectionFactory();
+        if (connectionFactory == null) {
+            log.severe("Connection factory is null for " + provider.getBroker());
+            return false;
+        }
 
         Connection connectiontmp = null;
         try {
@@ -386,6 +390,10 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
             String ltopic = PluginUtils.getSubstitutedValue(getTopic(provider), run.getEnvironment(listener));
             if (provider.getAuthenticationMethod() != null && ltopic != null && provider.getBroker() != null) {
                 ActiveMQConnectionFactory connectionFactory = provider.getConnectionFactory();
+                if (connectionFactory == null) {
+                    log.severe("Connection factory is null for " + provider.getBroker());
+                    return new SendResult(false, mesgId, mesgContent);
+                }
                 connection = connectionFactory.createConnection();
                 connection.start();
 
@@ -519,6 +527,10 @@ public class ActiveMqMessagingWorker extends JMSMessagingWorker {
             MessageConsumer consumer = null;
             try {
                 ActiveMQConnectionFactory connectionFactory = provider.getConnectionFactory();
+                if (connectionFactory == null) {
+                    log.severe("Connection factory is null for " + provider.getBroker());
+                    return null;
+                }
                 connection = connectionFactory.createConnection();
                 connection.setClientID(ip + "_" + UUID.randomUUID());
                 connection.start();

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
@@ -2,11 +2,19 @@ package com.redhat.jenkins.plugins.ci.messaging;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
 import java.util.Collections;
 
+import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.junit.Test;
 
@@ -70,5 +78,111 @@ public class ActiveMqMessagingWorkerTest {
         JsonNode root = mapper.readTree(headers);
 
         assertThat(root.get("JMSDestination").asText(), is("topic://VirtualTopic.test"));
+    }
+
+    @Test
+    public void connect_deafBroker_failsWithinTimeout() throws Exception {
+        try (ServerSocket deafServer = new ServerSocket(0)) {
+            int port = deafServer.getLocalPort();
+
+            Thread acceptor = new Thread(() -> {
+                try {
+                    while (true) {
+                        Socket s = deafServer.accept();
+                        Thread.sleep(120_000);
+                        s.close();
+                    }
+                } catch (Exception ignored) {
+                }
+            });
+            acceptor.setDaemon(true);
+            acceptor.start();
+
+            ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(
+                    "tcp://localhost:" + port + "?wireFormat.maxInactivityDuration=3000");
+            factory.setConnectResponseTimeout(3_000);
+            factory.setSendTimeout(3_000);
+            ActiveMqMessagingProvider provider = mock(ActiveMqMessagingProvider.class);
+            when(provider.getConnectionFactory()).thenReturn(factory);
+            when(provider.getBroker()).thenReturn("tcp://localhost:" + port);
+            when(provider.getName()).thenReturn("test-provider");
+
+            ActiveMqMessagingWorker worker = new ActiveMqMessagingWorker(provider, null, "test-job");
+
+            assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
+                boolean connected = worker.connect();
+                assertFalse("connect() should return false when broker is unresponsive", connected);
+            }, "connect() hung for >20s against an unresponsive broker (issue #381)");
+        }
+    }
+
+    @Test
+    public void connect_staleBroker_failsWithinConnectResponseTimeout() throws Exception {
+        try (ServerSocket server = new ServerSocket(0)) {
+            int port = server.getLocalPort();
+
+            Thread fakeServer = new Thread(() -> {
+                try {
+                    Socket s = server.accept();
+                    DataInputStream din = new DataInputStream(s.getInputStream());
+                    DataOutputStream dout = new DataOutputStream(s.getOutputStream());
+
+                    // Read client's WireFormatInfo (size-prefixed frame)
+                    int size = din.readInt();
+                    byte[] frame = new byte[size];
+                    din.readFully(frame);
+
+                    // Echo it back — client accepts any valid WireFormatInfo
+                    dout.writeInt(size);
+                    dout.write(frame);
+                    dout.flush();
+
+                    // WireFormat negotiation complete — now go silent.
+                    // Never respond to ConnectionInfo, simulating a stale broker.
+                    Thread.sleep(120_000);
+                    s.close();
+                } catch (Exception ignored) {
+                }
+            });
+            fakeServer.setDaemon(true);
+            fakeServer.start();
+
+            ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("tcp://localhost:" + port);
+            factory.setConnectResponseTimeout(3_000);
+            ActiveMqMessagingProvider provider = mock(ActiveMqMessagingProvider.class);
+            when(provider.getConnectionFactory()).thenReturn(factory);
+            when(provider.getBroker()).thenReturn("tcp://localhost:" + port);
+            when(provider.getName()).thenReturn("test-provider");
+
+            ActiveMqMessagingWorker worker = new ActiveMqMessagingWorker(provider, null, "test-job");
+
+            assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+                boolean connected = worker.connect();
+                assertFalse("connect() should return false when broker goes silent after handshake", connected);
+            }, "connect() hung against a stale broker — connectResponseTimeout did not fire (issue #381)");
+        }
+    }
+
+    @Test
+    public void getConnectionFactory_setsTimeouts() {
+        ActiveMqMessagingProvider provider = mock(ActiveMqMessagingProvider.class,
+                org.mockito.Mockito.CALLS_REAL_METHODS);
+        ActiveMQConnectionFactory inputFactory = new ActiveMQConnectionFactory("tcp://localhost:61616");
+
+        org.apache.activemq.ActiveMQConnectionFactory result = provider.getConnectionFactory("tcp://localhost:61616",
+                new com.redhat.jenkins.plugins.ci.authentication.activemq.ActiveMQAuthenticationMethod() {
+                    @Override
+                    public ActiveMQConnectionFactory getConnectionFactory(String broker) {
+                        return inputFactory;
+                    }
+
+                    @Override
+                    public hudson.model.Descriptor<com.redhat.jenkins.plugins.ci.authentication.activemq.ActiveMQAuthenticationMethod> getDescriptor() {
+                        return null;
+                    }
+                });
+
+        assertThat(result.getConnectResponseTimeout(), is(ActiveMqMessagingProvider.CONNECT_RESPONSE_TIMEOUT_MS));
+        assertThat(result.getSendTimeout(), is(ActiveMqMessagingProvider.SEND_TIMEOUT_MS));
     }
 }

--- a/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
+++ b/plugin/src/test/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorkerTest.java
@@ -164,6 +164,19 @@ public class ActiveMqMessagingWorkerTest {
     }
 
     @Test
+    public void connect_returnsFalseWhenConnectionFactoryIsNull() {
+        ActiveMqMessagingProvider provider = mock(ActiveMqMessagingProvider.class);
+        when(provider.getConnectionFactory()).thenReturn(null);
+        when(provider.getBroker()).thenReturn("tcp://localhost:61616");
+        when(provider.getName()).thenReturn("test-provider");
+
+        ActiveMqMessagingWorker worker = new ActiveMqMessagingWorker(provider, null, "test-job");
+        boolean connected = worker.connect();
+
+        assertFalse("connect() should return false when factory is null", connected);
+    }
+
+    @Test
     public void getConnectionFactory_setsTimeouts() {
         ActiveMqMessagingProvider provider = mock(ActiveMqMessagingProvider.class,
                 org.mockito.Mockito.CALLS_REAL_METHODS);


### PR DESCRIPTION
## Summary

- Sets `connectResponseTimeout` (60s) and `sendTimeout` (60s) on every `ActiveMQConnectionFactory` returned by `ActiveMqMessagingProvider.getConnectionFactory()`
- Without these timeouts, `setClientID()` → `ensureConnectionInfoSent()` → `syncSendPacket()` blocks forever on `FutureResponse.getResult()` when the broker is unresponsive
- Adds a deaf-server integration test that verifies `connect()` fails cleanly instead of hanging
- Adds a unit test verifying the factory timeout properties are set

Fixes #381

## Test plan

- [x] New test `connect_deafBroker_failsWithinTimeout` — spins up a TCP server that accepts connections but never speaks OpenWire; verifies `connect()` returns `false` within a bounded time
- [x] New test `getConnectionFactory_setsTimeouts` — verifies `connectResponseTimeout` and `sendTimeout` are set on the returned factory
- [x] All existing unit tests pass
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)