### PR TITLE
Migrate Commons Lang from 2 to 3 and StrSubstitutor to Commons Text

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -55,6 +55,7 @@
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <spotbugs.failOnError>false</spotbugs.failOnError>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
 
     <dependencyManagement>

--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/ActiveMqMessagingWorker.java
@@ -44,8 +44,8 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/KafkaMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/KafkaMessagingWorker.java
@@ -42,8 +42,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;

--- a/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
+++ b/plugin/src/main/java/com/redhat/jenkins/plugins/ci/messaging/RabbitMQMessagingWorker.java
@@ -13,8 +13,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.CancelCallback;

--- a/plugin/src/main/java/com/redhat/utils/PluginUtils.java
+++ b/plugin/src/main/java/com/redhat/utils/PluginUtils.java
@@ -26,7 +26,7 @@ package com.redhat.utils;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 
 import hudson.EnvVars;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
@@ -41,10 +41,10 @@ public class PluginUtils {
         }
         String text = id.replaceAll("\\$([a-zA-Z_]+[a-zA-Z0-9_]*)", "\\${$1}"); // replace $VAR instances with ${VAR}.
         if (env != null) {
-            StrSubstitutor sub1 = new StrSubstitutor(env);
+            StringSubstitutor sub1 = new StringSubstitutor(env);
             text = sub1.replace(text).trim();
         }
-        StrSubstitutor sub2 = new StrSubstitutor(getNodeGlobalProperties());
+        StringSubstitutor sub2 = new StringSubstitutor(getNodeGlobalProperties());
         return sub2.replace(text).trim();
     }
 


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed
- `exception.ExceptionUtils` moves to `org.apache.commons.lang3` in the three messaging workers.
- `text.StrSubstitutor` moves to Commons Text as `StringSubstitutor` — Commons Text is where that
  class lives now, and Lang 3 has no replacement for it.
- Enabled the `ban-commons-lang-2` enforcer rule to prevent regressions.

Both `commons-lang3-api` and `commons-text-api` were already declared, so no dependency changes were
needed.

### Testing done

`mvn -B -ntp clean verify` compiles and passes the unit tests locally on Java 21 / macOS.

The Docker-backed integration suites (`AmqMessagingPluginIntegrationTest`, `KafkaMessagingPluginIntegrationTest`, `RabbitMQ*`) were **not** verified locally — they need broker containers that my machine could not run reliably, so I am leaving them for CI to judge rather than reporting a result I did not get.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
